### PR TITLE
Feature/32 smart router

### DIFF
--- a/src/matrixmouse/_service.py
+++ b/src/matrixmouse/_service.py
@@ -107,7 +107,7 @@ def _stop_ollama_models() -> None:
     """
     Unload all configured models from Ollama VRAM.
 
-    Uses the config model fields (coder_model, manager_model, etc.) rather
+    Uses the config cascade fields (manager_cascade, coder_cascade, etc.) rather
     than `ollama ps` so we don't accidentally stop unrelated models running
     on the same machine.
 
@@ -420,6 +420,9 @@ def main() -> None:
         # --- Memory and comms ---
         memory.configure(paths.agent_notes)
         comms.configure(_config)
+
+        # --- Workspace state repository ---
+        ws_state_repo = SQLiteWorkspaceStateRepository(paths.db_file)
 
         # --- Token budget tracker ---
         from matrixmouse.inference.token_budget import TokenBudgetTracker

--- a/src/matrixmouse/_service.py
+++ b/src/matrixmouse/_service.py
@@ -409,6 +409,7 @@ def main() -> None:
             )
 
         # --- Model validation ---
+        budget_tracker = None  # Will be constructed below, passed to Router after
         router = Router(_config)        # parse + local_only check
         router.ensure_all_models()     # pull/verify each model
 
@@ -438,15 +439,34 @@ def main() -> None:
             _config.openai_tokens_per_day,
         )
 
+        # --- Backend Availability Cache ---
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+        availability_cache = BackendAvailabilityCache(
+            ws_state_repo=ws_state_repo,
+            initial_cooldown_seconds=_config.backend_cooldown_initial_seconds,
+            max_cooldown_seconds=_config.backend_cooldown_max_seconds,
+        )
+        logger.info(
+            "Backend availability cache initialised: "
+            "initial=%ds, max=%ds",
+            _config.backend_cooldown_initial_seconds,
+            _config.backend_cooldown_max_seconds,
+        )
+
+        # --- Rebuild router with budget_tracker (backends need it) ---
+        # Router was already constructed above for validation, but backends
+        # need the budget_tracker for token accounting. Rebuild it now.
+        router = Router(_config, budget_tracker=budget_tracker)
+
         # --- Orchestrator ---
         queue = SQLiteTaskRepository(paths.db_file)
-        ws_state_repo = SQLiteWorkspaceStateRepository(paths.db_file)
         orchestrator = Orchestrator(
             config=_config,
             paths=paths,
             queue=queue,
             ws_state_repo=ws_state_repo,
             budget_tracker=budget_tracker,
+            availability_cache=availability_cache,
         )
         orchestrator.configure_api()
 

--- a/src/matrixmouse/_service.py
+++ b/src/matrixmouse/_service.py
@@ -118,20 +118,20 @@ def _stop_ollama_models() -> None:
         logger.debug("Config not loaded — skipping ollama model unload.")
         return
 
-    # Collect all unique model names across all roles
-    model_fields = [
-        _config.coder_model,
-        _config.manager_model,
-        _config.summarizer_model,
-        _config.critic_model,
-        _config.writer_model,
+    # Collect all unique model names across all role cascades
+    cascade_fields = [
+        _config.manager_cascade,
+        _config.critic_cascade,
+        _config.writer_cascade,
+        _config.coder_cascade,
+        _config.merge_resolution_cascade,
+        _config.summarizer_cascade,
     ]
 
-    # coder_cascade is a list — flatten it
-    cascade = _config.coder_cascade or []
-    if isinstance(cascade, str):
-        cascade = [m.strip() for m in cascade.split(",") if m.strip()]
-    model_fields.extend(cascade)
+    model_fields = []
+    for cascade in cascade_fields:
+        if cascade:
+            model_fields.extend(cascade)
 
     models = list(dict.fromkeys(m for m in model_fields if m))  # unique, ordered
 
@@ -213,15 +213,18 @@ def _load_inference_secrets(config) -> None:
     """
     from matrixmouse.router import parse_model_string, _REMOTE_BACKENDS
 
-    # Collect every configured model string
-    all_model_strings = [
-        config.manager_model,
-        config.coder_model,
-        config.writer_model,
-        config.critic_model,
-        config.summarizer_model,
-        config.merge_resolution_model,
-    ] + list(config.coder_cascade)
+    # Collect every configured model string from all cascades
+    all_model_strings: list[str] = []
+    for cascade in [
+        config.manager_cascade,
+        config.critic_cascade,
+        config.writer_cascade,
+        config.coder_cascade,
+        config.merge_resolution_cascade,
+        config.summarizer_cascade,
+    ]:
+        if cascade:
+            all_model_strings.extend(cascade)
 
     backends_in_use: set[str] = set()
     for model_string in all_model_strings:

--- a/src/matrixmouse/config.py
+++ b/src/matrixmouse/config.py
@@ -63,25 +63,69 @@ class MatrixMouseConfig(BaseSettings):
         default=True,
         description="Prevent non-local LLM inference if True, allows if False."
     )
-    coder_model: str = Field(
-        default="http://localhost:11434:ollama:qwen3.5:2b",
-        description="Model for code generation and implementation tasks.",
+    manager_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for the Manager role. Most-preferred first. "
+            "Manager prefers the most capable model — list largest/most capable first, "
+            "smaller fallbacks after. Falls back down the list on provider unavailability."
+        ),
     )
-    writer_model: str = Field(
-        default="http://localhost:11434:ollama:qwen3.5:2b",
-        description="Model for prose generation tasks. (Not for source code).",
+    critic_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for the Critic role. Most-preferred first. "
+            "Prefer strong reasoning models. Falls back on unavailability."
+        ),
     )
-    manager_model: str = Field(
-        default="http://localhost:11434:ollama:qwen3.5:2b",
-        description="Model for planning, design, and architectural decisions.",
+    writer_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for the Writer role. Most-preferred first. "
+            "Falls back on unavailability."
+        ),
     )
-    critic_model: str = Field(
-        default="http://localhost:11434:ollama:qwen3.5:2b",
-        description="Model for critique, review, and stuck detection.",
+    coder_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for the Coder role. Most-preferred first. "
+            "Coder prefers the smallest/cheapest model that can do the work — list "
+            "smallest first, escalate to larger on stuck OR provider unavailability."
+        ),
     )
-    summarizer_model: str = Field(
-        default="http://localhost:11434:ollama:qwen3.5:2b",
-        description="Model for context summarisation. Should be small and fast.",
+    merge_resolution_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for merge conflict resolution. "
+            "Most-preferred first. Defaults to [coder_cascade[-1]] if not set. "
+            "Falls back on unavailability."
+        ),
+    )
+    summarizer_cascade: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered model preference list for context summarisation. Most-preferred "
+            "first. Required — startup fails if empty. If all entries are unavailable "
+            "at runtime, SummarizationUnavailableError is raised and the task yields "
+            "for retry rather than silently skipping compression. A task that cannot "
+            "summarise context will become permanently stuck as the context window fills. "
+            "Prefer a small/fast local model to avoid burning remote token budget on "
+            "housekeeping."
+        ),
+    )
+    backend_cooldown_initial_seconds: int = Field(
+        default=30,
+        description=(
+            "Initial cooldown in seconds after the first backend connection failure. "
+            "Doubles on each consecutive failure up to backend_cooldown_max_seconds."
+        ),
+    )
+    backend_cooldown_max_seconds: int = Field(
+        default=600,
+        description=(
+            "Maximum backend connection failure cooldown in seconds. "
+            "Ceiling for the exponential backoff applied after repeated connection failures."
+        ),
     )
     agent_max_turns: int = Field(
         default=50,
@@ -89,16 +133,6 @@ class MatrixMouseConfig(BaseSettings):
             "Maximum turns an agent may take on a single task before the "
             "task is moved to BLOCKED_BY_HUMAN. The operator can extend, "
             "respec, or cancel via the turn-limit response endpoint."
-        ),
-    )
-
-    # --- Coder cascade ---
-    coder_cascade: list[str] = Field(
-        default=["http://localhost:11434:ollama:qwen3.5:4b", "http://localhost:11434:ollama:qwen3.5:9b", "http://localhost:11434:ollama:qwen3.5:27b"],
-        description=(
-            "Ordered list of models for the coder cascade, smallest to largest. "
-            "If only one entry, no escalation occurs. "
-            "Example: ['http://localhost:11434:ollama:qwen2.5-coder:7b', 'http://localhost:11434:ollama:qwen2.5-coder:14b', 'http://localhost:11434:ollama:qwen2.5-coder:30b']"
         ),
     )
 
@@ -372,14 +406,6 @@ class MatrixMouseConfig(BaseSettings):
         description=(
             "Maximum turns an agent may take to resolve a merge conflict "
             "before the task is escalated to BLOCKED_BY_HUMAN."
-        ),
-    )
-    merge_resolution_model: str = Field(
-        default="",
-        description=(
-            "Model to use for merge conflict resolution. "
-            "Empty string means use the last (largest) model in coder_cascade. "
-            "Override to pin a specific model: e.g. 'qwen2.5-coder:32b'."
         ),
     )
     push_wip_to_remote: bool = Field(

--- a/src/matrixmouse/context.py
+++ b/src/matrixmouse/context.py
@@ -9,7 +9,7 @@ Responsibilities:
       (default: 60% of model context length, capped at ~32k tokens regardless
       of model maximum)
     - Performing summarisation using a small, fast model (separate from the
-      working model) via config.summarizer_model
+      working model) via the summarizer cascade
     - Preserving: system prompt, original task instruction, last N turns
       (default: 6)
     - Replacing middle history with a compressed summary message marked
@@ -79,14 +79,19 @@ class ContextManager:
         context_manager = ContextManager(
             config=config,
             paths=paths,
-            coder_model=router.parsed_model_for_role(AgentRole.CODER).model,
-            coder_backend=router.backend_for_role(AgentRole.CODER),
-            summarizer_backend=router.get_backend(config.summarizer_model),
-            summarizer_model=router.local_model_for_role(config.summarizer_model),
+            coder_model=working_parsed.model,
+            coder_backend=working_backend,
+            summarizer_backend=summarizer_backend,
+            summarizer_model=summarizer_parsed.model,
         )
         loop = AgentLoop(..., context_manager=context_manager)
 
     The loop calls ``context_manager(messages, config)`` before each inference.
+
+    Note: ``coder_model``/``coder_backend`` are legacy parameter names that will
+    be renamed to ``working_model``/``working_backend`` in a future phase. They
+    accept whichever model is resolved from the cascade for the current task's
+    role — not just Coder.
 
     Args:
         config: MatrixMouseConfig instance.

--- a/src/matrixmouse/context.py
+++ b/src/matrixmouse/context.py
@@ -8,8 +8,9 @@ Responsibilities:
     - Triggering summarisation when usage exceeds a configurable soft limit
       (default: 60% of model context length, capped at ~32k tokens regardless
       of model maximum)
-    - Performing summarisation using a small, fast model (separate from the
-      working model) via the summarizer cascade
+    - Performing summarisation using a small, fast model from the
+      summarizer cascade — walks the cascade and raises
+      SummarizationUnavailableError if all entries are unavailable
     - Preserving: system prompt, original task instruction, last N turns
       (default: 6)
     - Replacing middle history with a compressed summary message marked
@@ -31,7 +32,9 @@ from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, RepoPaths
 from matrixmouse.inference.base import LLMBackend, TextBlock
 
 if TYPE_CHECKING:
-    pass
+    from matrixmouse.router import Router
+    from matrixmouse.inference.availability import BackendAvailabilityCache
+    from matrixmouse.inference.base import SummarizationUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -79,47 +82,44 @@ class ContextManager:
         context_manager = ContextManager(
             config=config,
             paths=paths,
-            coder_model=working_parsed.model,
-            coder_backend=working_backend,
-            summarizer_backend=summarizer_backend,
-            summarizer_model=summarizer_parsed.model,
+            working_model=working_parsed.model,
+            working_backend=working_backend,
+            router=router,
+            availability_cache=availability_cache,
         )
         loop = AgentLoop(..., context_manager=context_manager)
 
     The loop calls ``context_manager(messages, config)`` before each inference.
 
-    Note: ``coder_model``/``coder_backend`` are legacy parameter names that will
-    be renamed to ``working_model``/``working_backend`` in a future phase. They
-    accept whichever model is resolved from the cascade for the current task's
-    role — not just Coder.
-
     Args:
         config: MatrixMouseConfig instance.
         paths: Resolved paths for this workspace.
-        coder_model: Backend-local model identifier for the working agent
+        working_model: Backend-local model identifier for the working agent
             (the portion after ``backend:`` in the full model string).
-            Used only to query the context length via coder_backend.
-        coder_backend: LLMBackend for the working agent — provides
+            Used to query the context length via working_backend.
+        working_backend: LLMBackend for the working agent — provides
             get_context_length().
-        summarizer_backend: LLMBackend for the summarizer model.
-        summarizer_model: Backend-local model identifier for the summarizer.
+        router: Router instance — used to access summarizer_cascade and
+            get_backend_for_model.
+        availability_cache: Optional BackendAvailabilityCache for checking
+            summarizer backend availability.
     """
 
     def __init__(
         self,
         config: MatrixMouseConfig,
         paths: MatrixMousePaths | RepoPaths,
-        coder_model: str,
-        coder_backend: LLMBackend,
-        summarizer_backend: LLMBackend,
-        summarizer_model: str,
+        working_model: str,
+        working_backend: LLMBackend,
+        router: "Router",
+        availability_cache: "BackendAvailabilityCache | None" = None,
     ) -> None:
         self.config = config
         self.paths = paths
-        self._summarizer_backend = summarizer_backend
-        self._summarizer_model = summarizer_model
+        self._router = router
+        self._availability_cache = availability_cache
 
-        raw_limit = coder_backend.get_context_length(coder_model)
+        raw_limit = working_backend.get_context_length(working_model)
         self.token_limit = min(raw_limit, config.context_soft_limit)
         self.compress_at = int(self.token_limit * config.compress_threshold)
 
@@ -204,6 +204,38 @@ class ContextManager:
         )
         return compressed
 
+    def _resolve_summarizer(self) -> tuple[LLMBackend, str]:
+        """Return the first available (backend, model_id) from summarizer_cascade.
+
+        Walks the summarizer cascade and checks each entry's backend
+        availability via the availability_cache. Returns the first
+        available backend and model identifier.
+
+        Raises:
+            SummarizationUnavailableError: If all entries are in cooldown or
+                the cascade is exhausted. This is a hard failure — callers must
+                not catch and swallow it. A task that cannot summarise will
+                become permanently stuck as its context window fills.
+        """
+        from matrixmouse.router import parse_model_string
+        from matrixmouse.inference.base import SummarizationUnavailableError
+
+        for model_str in self._router.summarizer_cascade():
+            parsed = parse_model_string(model_str)
+            if self._availability_cache is not None:
+                if not self._availability_cache.is_available(parsed.backend):
+                    logger.debug(
+                        "Summarizer backend '%s' in cooldown, skipping.",
+                        parsed.backend,
+                    )
+                    continue
+            backend = self._router.get_backend_for_model(model_str)
+            return backend, parsed.model
+
+        raise SummarizationUnavailableError(
+            "All summarizer cascade entries are unavailable."
+        )
+
     def _summarise(self, messages: list) -> str:
         """Use the summarizer backend to produce a concise summary.
 
@@ -212,7 +244,16 @@ class ContextManager:
 
         Returns:
             Summary text as a string.
+
+        Raises:
+            SummarizationUnavailableError: If no summarizer backend is
+                available. This exception propagates to the orchestrator
+                and must NOT be caught here.
         """
+        # Resolve the summarizer backend — raises SummarizationUnavailableError
+        # if all cascade entries are exhausted.
+        backend, model_id = self._resolve_summarizer()
+
         transcript_parts = []
         for m in messages:
             role = m.get("role", "unknown") if isinstance(m, dict) else "unknown"
@@ -242,26 +283,18 @@ class ContextManager:
             f"Work log to summarise:\n\n{transcript}"
         )
 
-        try:
-            response = self._summarizer_backend.chat(
-                model=self._summarizer_model,
-                messages=[{"role": "user", "content": prompt}],
-                tools=[],
-                stream=False,
-            )
-            # Extract text from the response content blocks
-            text_parts = [
-                b.text for b in response.content
-                if isinstance(b, TextBlock) and b.text
-            ]
-            return "\n".join(text_parts) or "(Empty summary returned.)"
-
-        except Exception as e:
-            logger.warning("Summarisation failed: %s. Using fallback summary.", e)
-            return (
-                f"(Summarisation failed: {e}. "
-                f"{len(messages)} messages were compressed without summary.)"
-            )
+        response = backend.chat(
+            model=model_id,
+            messages=[{"role": "user", "content": prompt}],
+            tools=[],
+            stream=False,
+        )
+        # Extract text from the response content blocks
+        text_parts = [
+            b.text for b in response.content
+            if isinstance(b, TextBlock) and b.text
+        ]
+        return "\n".join(text_parts) or "(Empty summary returned.)"
 
     def _save_discoveries_to_notes(self, messages: list) -> None:
         """Extract and append notable discoveries to AGENT_NOTES.md.
@@ -299,10 +332,10 @@ def check_and_compress(
     messages: list,
     config: MatrixMouseConfig,
     paths: MatrixMousePaths | RepoPaths,
-    coder_model: str,
-    coder_backend: LLMBackend,
-    summarizer_backend: LLMBackend,
-    summarizer_model: str,
+    working_model: str,
+    working_backend: LLMBackend,
+    router: "Router",
+    availability_cache: "BackendAvailabilityCache | None" = None,
 ) -> list:
     """Functional interface for context checking — creates a ContextManager
     and calls it in one step.
@@ -314,10 +347,10 @@ def check_and_compress(
         messages: Current message history.
         config: Active MatrixMouseConfig.
         paths: Resolved MatrixMousePaths.
-        coder_model: Backend-local model identifier for the working agent.
-        coder_backend: LLMBackend for the working agent.
-        summarizer_backend: LLMBackend for the summarizer model.
-        summarizer_model: Backend-local model identifier for the summarizer.
+        working_model: Backend-local model identifier for the working agent.
+        working_backend: LLMBackend for the working agent.
+        router: Router instance for summarizer cascade resolution.
+        availability_cache: Optional availability cache for summarizer checks.
 
     Returns:
         The message list, compressed if necessary.
@@ -325,9 +358,9 @@ def check_and_compress(
     manager = ContextManager(
         config=config,
         paths=paths,
-        coder_model=coder_model,
-        coder_backend=coder_backend,
-        summarizer_backend=summarizer_backend,
-        summarizer_model=summarizer_model,
+        working_model=working_model,
+        working_backend=working_backend,
+        router=router,
+        availability_cache=availability_cache,
     )
     return manager(messages, config)

--- a/src/matrixmouse/inference/anthropic.py
+++ b/src/matrixmouse/inference/anthropic.py
@@ -11,8 +11,9 @@ the canonical internal format (Anthropic-style content blocks) maps almost
 directly to the wire format, so message translation is minimal compared to
 the OpenAI-compat adapters.
 
-Token budget tracking is injected via TokenBudgetTracker (Phase 4). Until
-then, usage is logged but not enforced.
+Token budget tracking is injected via TokenBudgetTracker.
+Usage is enforced — ``chat()`` raises ``TokenBudgetExceededError``
+when the configured budget is exceeded.
 
 Streaming is handled internally via the Anthropic streaming API. When
 ``stream=True`` and ``chunk_callback`` is provided, text tokens are

--- a/src/matrixmouse/inference/availability.py
+++ b/src/matrixmouse/inference/availability.py
@@ -1,0 +1,224 @@
+"""
+matrixmouse/inference/availability.py
+
+BackendAvailabilityCache — tracks connection failure state per backend
+using exponential backoff.
+
+Persists to WorkspaceStateRepository (existing workspace_state key-value
+table, key prefix ``backend_availability:{name}``) so cooldowns survive
+service restarts and are visible across workers. No new schema table required.
+
+Storage value schema:
+{
+    "consecutive_failures": 3,
+    "cooldown_until": "2026-04-02T04:30:00+00:00",
+    "last_failure_at": "2026-04-02T04:20:00+00:00"
+}
+
+Backoff calculation:
+    cooldown_duration = min(initial * 2^(consecutive_failures - 1), max)
+
+| Failure # | Duration (defaults) |
+|-----------|---------------------|
+| 1         | 30s                 |
+| 2         | 60s                 |
+| 3         | 120s                |
+| 4         | 240s                |
+| 5+        | 600s (cap)          |
+
+``record_failure`` guards against stale cooldown compounding: if the stored
+``cooldown_until`` is already in the past when read, ``consecutive_failures``
+is reset to 0 before incrementing. A backend that recovered and then failed
+again gets a fresh backoff sequence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from matrixmouse.repository.workspace_state_repository import (
+    WorkspaceStateRepository,
+)
+
+# Prefix for storage keys in the workspace state repository.
+_AVAILABILITY_PREFIX = "backend_availability:"
+
+
+class BackendAvailabilityCache:
+    """Tracks connection failure state per backend using exponential backoff.
+
+    Persists to WorkspaceStateRepository so cooldowns survive service restarts
+    and are visible across workers.
+    """
+
+    def __init__(
+        self,
+        ws_state_repo: WorkspaceStateRepository,
+        initial_cooldown_seconds: int = 30,
+        max_cooldown_seconds: int = 600,
+    ) -> None:
+        self._repo = ws_state_repo
+        self._initial = initial_cooldown_seconds
+        self._max = max_cooldown_seconds
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def is_available(self, backend: str) -> bool:
+        """True if the backend has no active cooldown.
+
+        Returns True if no record exists or cooldown_until has passed.
+
+        Args:
+            backend: Backend identifier string, e.g. ``"anthropic"``.
+
+        Returns:
+            True if the backend is available, False if in cooldown.
+        """
+        record = self._read_record(backend)
+        if record is None:
+            return True
+
+        cooldown_until = record.get("cooldown_until")
+        if cooldown_until is None:
+            return True
+
+        try:
+            cooldown_dt = datetime.fromisoformat(cooldown_until)
+            return datetime.now(timezone.utc) >= cooldown_dt
+        except (ValueError, TypeError):
+            return True
+
+    def record_failure(self, backend: str) -> datetime:
+        """Record a connection failure and return the new cooldown_until.
+
+        Resets consecutive_failures to 0 first if prior cooldown_until
+        has already passed (stale failure run — treat as fresh start).
+
+        Args:
+            backend: Backend identifier string.
+
+        Returns:
+            The new cooldown_until datetime after this failure.
+        """
+        now = datetime.now(timezone.utc)
+        record = self._read_record(backend)
+
+        if record is not None:
+            # Check if prior cooldown has expired — reset if stale
+            cooldown_until = record.get("cooldown_until")
+            if cooldown_until is not None:
+                try:
+                    cooldown_dt = datetime.fromisoformat(cooldown_until)
+                    if now >= cooldown_dt:
+                        # Stale run — treat as fresh start
+                        record["consecutive_failures"] = 0
+                except (ValueError, TypeError):
+                    pass
+            consecutive = record.get("consecutive_failures", 0) + 1
+        else:
+            consecutive = 1
+
+        # Backoff: min(initial * 2^(failures - 1), max)
+        backoff = min(
+            self._initial * (2 ** (consecutive - 1)),
+            self._max,
+        )
+        cooldown_until = now + timedelta(seconds=backoff)
+
+        new_record: dict[str, Any] = {
+            "consecutive_failures": consecutive,
+            "cooldown_until": cooldown_until.isoformat(),
+            "last_failure_at": now.isoformat(),
+        }
+        self._write_record(backend, new_record)
+        return cooldown_until
+
+    def record_success(self, backend: str) -> None:
+        """Clear failure state after successful inference.
+
+        No-op if no record exists.
+
+        Args:
+            backend: Backend identifier string.
+        """
+        record = self._read_record(backend)
+        if record is None:
+            return
+
+        record["consecutive_failures"] = 0
+        record["cooldown_until"] = None
+        self._write_record(backend, record)
+
+    def earliest_available_at(self, backends: list[str]) -> datetime | None:
+        """Return the earliest time any of the given backends exits cooldown.
+
+        Returns None if any backend is already available.
+        Used only when all cascade options have been exhausted.
+
+        Args:
+            backends: List of backend identifier strings.
+
+        Returns:
+            Earliest cooldown_until across all backends, or None if any
+            backend is available or the list is empty.
+        """
+        if not backends:
+            return None
+
+        cooldown_times: list[datetime] = []
+
+        for backend in backends:
+            if self.is_available(backend):
+                return None  # At least one is available
+
+            record = self._read_record(backend)
+            if record is not None and record.get("cooldown_until"):
+                cooldown_times.append(
+                    datetime.fromisoformat(record["cooldown_until"])
+                )
+
+        if not cooldown_times:
+            return None
+
+        return min(cooldown_times).isoformat()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _storage_key(self, backend: str) -> str:
+        """Build the namespaced storage key for a backend.
+
+        Args:
+            backend: Backend identifier string.
+
+        Returns:
+            Key like ``backend_availability:anthropic``.
+        """
+        return f"{_AVAILABILITY_PREFIX}{backend}"
+
+    def _read_record(self, backend: str) -> dict[str, Any] | None:
+        """Read and return the availability record for a backend.
+
+        Args:
+            backend: Backend identifier string.
+
+        Returns:
+            Parsed record dict, or None if no record exists.
+        """
+        key = self._storage_key(backend)
+        return self._repo.get(key)
+
+    def _write_record(self, backend: str, record: dict[str, Any]) -> None:
+        """Persist an availability record.
+
+        Args:
+            backend: Backend identifier string.
+            record: Record dict to store (must be JSON-serialisable).
+        """
+        key = self._storage_key(backend)
+        self._repo.set(key, record)

--- a/src/matrixmouse/inference/base.py
+++ b/src/matrixmouse/inference/base.py
@@ -177,13 +177,26 @@ class TokenBudgetExceededError(LLMBackendError):
         self.limit = limit
         self.used = used
         self.retry_after = retry_after
-        
+
         message = (
             f"{provider} {period} token budget exhausted: {used}/{limit} tokens used"
         )
         if retry_after is not None:
             message += f". Retry after {retry_after.isoformat()}"
         super().__init__(message)
+
+
+class SummarizationUnavailableError(LLMBackendError):
+    """Raised when no summarizer backend is available to compress context.
+
+    This is a hard failure, not a graceful degradation. A task that cannot
+    summarise its context will become permanently stuck as the context window
+    fills. The orchestrator catches this and yields the task to READY so the
+    scheduler retries when a summarizer backend becomes available again.
+
+    Callers must not catch and swallow this exception. It must propagate to
+    the orchestrator.
+    """
 
 
 # ---------------------------------------------------------------------------

--- a/src/matrixmouse/loop.py
+++ b/src/matrixmouse/loop.py
@@ -25,7 +25,7 @@ from enum import Enum, auto
 from typing import Any, Callable
 
 from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, RepoPaths
-from matrixmouse.inference.base import LLMBackend, LLMResponse, ToolUseBlock, Tool
+from matrixmouse.inference.base import LLMBackend, LLMResponse, ToolUseBlock, Tool, LLMBackendError
 from matrixmouse.tools import TOOL_REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -188,6 +188,8 @@ class AgentLoop:
             # --- Inference ---
             try:
                 response = self._chat_completion()
+            except LLMBackendError:
+                raise  # propagate to orchestrator
             except Exception as e:
                 logger.warning("chat_completion failed: %s", e)
                 self.messages.append({

--- a/src/matrixmouse/orchestrator.py
+++ b/src/matrixmouse/orchestrator.py
@@ -1236,10 +1236,42 @@ class Orchestrator:
         task.wait_reason = wait_reason
         task.status = TaskStatus.WAITING
         self.queue.update(task)
-        logger.info(
-            "Task [%s]: all backends exhausted. WAITING until %s (reason: %s).",
-            task.id, wait_until.isoformat(), wait_reason,
+
+        # Mark the backend as exhausted for the current scheduling cycle
+        # so other tasks on the same backend are not retried needlessly.
+        if budget_provider is not None:
+            self._mark_backend_exhausted(budget_provider)
+
+        logger.warning(
+            "Task [%s] waiting on %s budget exhaustion. "
+            "wait_until=%s",
+            task.id, budget_provider or "unknown", wait_until.isoformat(),
         )
+
+        # Emit notification so the operator knows a task is waiting
+        from matrixmouse import comms as comms_module
+        m = comms_module.get_manager()
+        if m:
+            try:
+                m.notify(
+                    title=f"Task [{task.id}] waiting — backends exhausted",
+                    message=(
+                        f"Task: {task.title}\\n"
+                        f"Provider: {budget_provider or cooldown_provider or 'unknown'}\\n"
+                        f"Earliest retry: {wait_until.isoformat()}"
+                    ),
+                )
+                m.emit("task_waiting_on_budget", {
+                    "task_id":    task.id,
+                    "task_title": task.title,
+                    "provider":   budget_provider or cooldown_provider or "unknown",
+                    "wait_until": wait_until.isoformat(),
+                })
+            except Exception as notify_err:
+                logger.warning(
+                    "Failed to emit budget exhaustion notification: %s",
+                    notify_err,
+                )
 
     def _run_task_with_model(self, task: Task, model: str) -> None:
         """Re-enter task execution with a pre-selected model.
@@ -1272,8 +1304,10 @@ class Orchestrator:
                 messages,
                 model=model,
             )
-        except TokenBudgetExceededError as e:
-            self._handle_budget_exhausted(task, e)
+        except TokenBudgetExceededError:
+            # Budget exhausted during _run_task_with_model escalation.
+            # All cascade entries are now exhausted — handle accordingly.
+            self._handle_all_backends_exhausted(task)
             return
 
         result   = run_result.loop_result
@@ -1337,27 +1371,7 @@ class Orchestrator:
         # If no model is available, handle exhaustion and return.
         resolved_model = self._resolve_model_for_task(task)
         if resolved_model is None:
-            # No cascade entry available — fall back to old budget check
-            # for backward compatibility during transition. Full
-            # _handle_all_backends_exhausted comes in Phase 3C.
-            if self._budget_tracker is not None:
-                cascade = self._router.cascade_for_role(task.role)
-                if cascade:
-                    parsed = parse_model_string(cascade[0])
-                    if parsed.is_remote:
-                        try:
-                            self._budget_tracker.check_budget(
-                                provider=parsed.backend,
-                                model=parsed.model,
-                            )
-                        except TokenBudgetExceededError as e:
-                            self._handle_budget_exhausted(task, e)
-                            return
-            logger.warning(
-                "Task [%s]: no model available from cascade. "
-                "Marking READY.", task.id,
-            )
-            self.queue.mark_ready(task.id)
+            self._handle_all_backends_exhausted(task)
             return
 
         if task.branch and task.repo:
@@ -2930,65 +2944,6 @@ class Orchestrator:
 
     
     
-    def _handle_budget_exhausted(
-        self,
-        task: "Task",
-        exc: "TokenBudgetExceededError",
-    ) -> None:
-        """Move a task to WAITING after a budget exhaustion event.
- 
-        Calculates wait_until from the exception\'s retry_after field
-        (which already incorporates both our tracker\'s window calculation
-        and any API-supplied Retry-After hint).
- 
-        Emits a one-time notification so the operator knows a task is
-        waiting on budget, then marks the backend as exhausted for the
-        current scheduling cycle so other tasks on the same backend are
-        not retried needlessly.
- 
-        Args:
-            task: The task whose inference was blocked by budget exhaustion.
-            exc:  The TokenBudgetExceededError carrying provider and wait_until.
-        """
-        wait_until_dt = exc.retry_after
-        wait_until_iso = wait_until_dt.isoformat() if wait_until_dt else None
- 
-        task.wait_until = wait_until_iso
-        task.wait_reason = f"budget:{exc.provider}"
-        task.status = TaskStatus.WAITING
-        self.queue.update(task)
- 
-        self._mark_backend_exhausted(exc.provider)
- 
-        logger.warning(
-            "Task [%s] waiting on %s budget exhaustion. "
-            "wait_until=%s",
-            task.id, exc.provider, wait_until_iso or "unknown",
-        )
-        from matrixmouse import comms as comms_module
-        m = comms_module.get_manager()
-        if m:
-            try:
-                m.notify(
-                    title=f"Task [{task.id}] waiting — {exc.provider} budget exhausted",
-                    message=(
-                        f"Task: {task.title}\\n"
-                        f"Provider: {exc.provider}\\n"
-                        f"Earliest retry: {wait_until_iso or 'unknown'}"
-                    ),
-                )
-                m.emit("task_waiting_on_budget", {
-                    "task_id":    task.id,
-                    "task_title": task.title,
-                    "provider":   exc.provider,
-                    "wait_until": wait_until_iso,
-                })
-            except Exception as notify_err:
-                logger.warning(
-                    "Failed to emit budget exhaustion notification: %s",
-                    notify_err,
-                )
- 
     def _maybe_promote_waiting_tasks(self) -> int:
         """Promote WAITING tasks whose wait_until has passed back to READY.
  

--- a/src/matrixmouse/orchestrator.py
+++ b/src/matrixmouse/orchestrator.py
@@ -37,7 +37,9 @@ from typing import Optional, TYPE_CHECKING
 from matrixmouse.agents import agent_for_role
 from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, RepoPaths
 from matrixmouse.context import ContextManager
-from matrixmouse.inference.base import TokenBudgetExceededError
+from matrixmouse.inference.base import (
+    TokenBudgetExceededError, BackendConnectionError, SummarizationUnavailableError,
+)
 from matrixmouse.inference.token_budget import TokenBudgetTracker
 if TYPE_CHECKING:
     from matrixmouse.inference.availability import BackendAvailabilityCache
@@ -1143,6 +1145,182 @@ class Orchestrator:
 
         return None
 
+    def _handle_all_backends_exhausted(self, task: Task) -> None:
+        """Handle the case where no cascade entry is available for a task.
+
+        Calculates wait_until as the earliest of:
+            - Budget retry_after values across all remote cascade entries
+            - Cooldown expiry times from the availability cache
+
+        If no wait_until can be determined (e.g. all-local cascade where
+        no cooldown data exists, or no budget tracker and no availability
+        cache): task returns to READY rather than WAITING. WAITING implies
+        a known retry time. Without one, READY + the scheduler's condition
+        variable idle handling provides natural backoff without creating a
+        busy loop or blocking the task indefinitely.
+
+        wait_reason is set to:
+            - budget:{provider} if budget is the limiting factor
+            - backend_unavailable:{provider} if cooldown is the limiting factor
+
+        Args:
+            task: The task to handle.
+        """
+        cascade = self._router.cascade_for_role(task.role)
+        if not cascade:
+            self.queue.mark_ready(task.id)
+            return
+
+        # Collect budget retry_after values for remote entries
+        budget_wait_times: list[datetime] = []
+        budget_provider: str | None = None
+
+        for model_string in cascade:
+            parsed = self._router.parse_model_string(model_string)
+            if parsed.is_remote and self._budget_tracker is not None:
+                retry_after = self._budget_tracker.get_retry_after(
+                    provider=parsed.backend,
+                    model=parsed.model,
+                )
+                if retry_after is not None:
+                    budget_wait_times.append(retry_after)
+                    if budget_provider is None:
+                        budget_provider = parsed.backend
+
+        # Collect cooldown expiry times
+        cooldown_wait_time: datetime | None = None
+        cooldown_provider: str | None = None
+
+        if self._availability_cache is not None:
+            backends_in_cascade = set()
+            for model_string in cascade:
+                parsed = self._router.parse_model_string(model_string)
+                backends_in_cascade.add(parsed.backend)
+
+            earliest = self._availability_cache.earliest_available_at(
+                list(backends_in_cascade)
+            )
+            if earliest is not None:
+                cooldown_wait_time = datetime.fromisoformat(earliest)
+                # Determine which provider the cooldown belongs to
+                for model_string in cascade:
+                    parsed = self._router.parse_model_string(model_string)
+                    if not self._availability_cache.is_available(parsed.backend):
+                        cooldown_provider = parsed.backend
+                        break
+
+        # Determine overall wait_until and wait_reason
+        wait_times = [t for t in budget_wait_times]
+        if cooldown_wait_time is not None:
+            wait_times.append(cooldown_wait_time)
+
+        if not wait_times:
+            # No wait time determinable → READY (avoids busy loop)
+            logger.warning(
+                "Task [%s]: all backends exhausted but no wait time "
+                "determinable — marking READY (no busy loop).", task.id,
+            )
+            self.queue.mark_ready(task.id)
+            return
+
+        wait_until = min(wait_times)
+
+        # Determine wait_reason: budget beats cooldown
+        if budget_wait_times and min(budget_wait_times) <= wait_until:
+            wait_reason = f"budget:{budget_provider}"
+        else:
+            wait_reason = f"backend_unavailable:{cooldown_provider}"
+
+        # Set WAITING status
+        task.wait_until = wait_until.isoformat()
+        task.wait_reason = wait_reason
+        task.status = TaskStatus.WAITING
+        self.queue.update(task)
+        logger.info(
+            "Task [%s]: all backends exhausted. WAITING until %s (reason: %s).",
+            task.id, wait_until.isoformat(), wait_reason,
+        )
+
+    def _run_task_with_model(self, task: Task, model: str) -> None:
+        """Re-enter task execution with a pre-selected model.
+
+        Used by the stuck escalation path to run the next cascade tier
+        without triggering the availability-based cascade walk, which would
+        reset to tier 0. Does not repeat git checkout or graph build — the
+        task is already set up from the outer _run_task call.
+
+        Args:
+            task:  The task to run.
+            model: The pre-resolved model string to use.
+        """
+        from matrixmouse.agents import agent_for_role
+
+        agent = agent_for_role(task.role)
+        messages = self._load_or_build_messages(task, agent)
+
+        self._update_status(
+            role=task.role.value,
+            model=model,
+            turns=0,
+            context_messages=messages,
+        )
+
+        try:
+            run_result = self._run_agent(
+                TaskRunContext(task=task, graph=self.graph),  # type: ignore[arg-type]
+                agent,
+                messages,
+                model=model,
+            )
+        except TokenBudgetExceededError as e:
+            self._handle_budget_exhausted(task, e)
+            return
+
+        result   = run_result.loop_result
+        detector = run_result.detector
+
+        # --- Yield ---
+        if result.exit_reason == LoopExitReason.YIELD:
+            self.queue.mark_ready(task.id)
+            return
+
+        # --- Complete ---
+        if result.exit_reason == LoopExitReason.COMPLETE:
+            self._handle_complete(task, result)
+            return
+
+        # --- Escalate (nested — no further escalation) ---
+        if result.exit_reason == LoopExitReason.ESCALATE:
+            # TODO(#15): current_cascade_index should live on Task, not be
+            # derived from resolved_model at runtime. Per-task tracking
+            # needed for multi-worker correctness and correct
+            # stuck-escalation persistence across context switches.
+            # Availability fallback always re-resolves from index 0
+            # (transient, try preferred again next cycle). Stuck escalation
+            # must persist (diagnostic, smaller model already proved
+            # insufficient). These require different state: availability
+            # uses BackendAvailabilityCache, stuck needs
+            # Task.current_cascade_index.
+            logger.warning(
+                "Task [%s]: stuck again at escalation tier %s. "
+                "Requesting human intervention.",
+                task.id, model,
+            )
+            self._request_human_intervention(
+                task, result,
+                reason="Stuck at escalation tier, still unable to make progress.",
+            )
+            return
+
+        # --- Decision / Error ---
+        if result.exit_reason == LoopExitReason.DECISION:
+            self._handle_decision(task, result)
+            return
+
+        self._request_human_intervention(
+            task, result, reason="Unrecoverable error in escalated task run."
+        )
+
     def _run_task(self, task: Task) -> None:
         """
         Run a single task to completion, yield, or block.
@@ -1311,12 +1489,45 @@ class Orchestrator:
 
         try:
             run_result = self._run_agent(ctx, agent, messages, model=resolved_model)
-        except TokenBudgetExceededError as e:
-            self._handle_budget_exhausted(task, e)
+        except SummarizationUnavailableError as e:
+            # Summarizer backend unavailable during context compression.
+            # Record failure on the summarizer backend, log, and yield.
+            if self._availability_cache is not None:
+                summarizer_cascade = self._router.summarizer_cascade()
+                if summarizer_cascade:
+                    parsed = self._router.parse_model_string(summarizer_cascade[0])
+                    self._availability_cache.record_failure(parsed.backend)
+            logger.warning(
+                "Task [%s]: summarisation unavailable (%s). "
+                "Marking READY for retry.", task.id, e,
+            )
+            self.queue.mark_ready(task.id)
             return
-        
+        except BackendConnectionError as e:
+            # Connection failure mid-loop — record failure and yield.
+            if self._availability_cache is not None:
+                parsed = self._router.parse_model_string(resolved_model)
+                self._availability_cache.record_failure(parsed.backend)
+            logger.warning(
+                "Task [%s]: backend connection error (%s). Marking READY.",
+                task.id, e,
+            )
+            self.queue.mark_ready(task.id)
+            return
+        except TokenBudgetExceededError as e:
+            # Budget exhausted mid-loop (burst over the upfront check).
+            self._mark_backend_exhausted(e.provider)
+            self.queue.mark_ready(task.id)
+            return
+
         result   = run_result.loop_result
         detector = run_result.detector
+
+        # --- Success: clear availability failure state ---
+        if result.exit_reason == LoopExitReason.COMPLETE:
+            if self._availability_cache is not None:
+                parsed = self._router.parse_model_string(resolved_model)
+                self._availability_cache.record_success(parsed.backend)
 
         # --- Yield (time slice expired or preemption) ---
         if result.exit_reason == LoopExitReason.YIELD:
@@ -1330,20 +1541,31 @@ class Orchestrator:
             return
 
         # --- Escalate (Coder cascade) ---
-        # TODO: make iterative for concurrency when multi-threaded model is applied
         if result.exit_reason == LoopExitReason.ESCALATE:
             if task.role == AgentRole.CODER:
-                escalated, new_model = self._router.escalate(detector)
-                if escalated:
-                    logger.info(
-                        "Task [%s] escalating to %s.", task.id, new_model,
-                    )
+                cascade = self._router.cascade_for_role(AgentRole.CODER)
+                # TODO(#15): current_cascade_index should live on Task, not be
+                # derived from resolved_model at runtime. Per-task tracking
+                # needed for multi-worker correctness and correct
+                # stuck-escalation persistence across context switches.
+                # Availability fallback always re-resolves from index 0
+                # (transient, try preferred again next cycle). Stuck escalation
+                # must persist (diagnostic, smaller model already proved
+                # insufficient). These require different state: availability
+                # uses BackendAvailabilityCache, stuck needs
+                # Task.current_cascade_index.
+                try:
+                    current_index = cascade.index(resolved_model)
+                except ValueError:
+                    current_index = 0
+                if current_index < len(cascade) - 1:
+                    next_model = cascade[current_index + 1]
                     handoff_messages = self._router.build_handoff(
                         detector, result.messages
                     )
                     task.context_messages = handoff_messages
                     self.queue.update(task)
-                    self._run_task(task)
+                    self._run_task_with_model(task, next_model)
                     return
             logger.warning(
                 "Task [%s] at cascade ceiling or non-escalatable role — "
@@ -1351,7 +1573,7 @@ class Orchestrator:
             )
             self._request_human_intervention(
                 task, result,
-                reason="At top of model cascade, still stuck.",
+                reason="At cascade ceiling, still stuck.",
             )
             return
 

--- a/src/matrixmouse/orchestrator.py
+++ b/src/matrixmouse/orchestrator.py
@@ -1750,19 +1750,13 @@ class Orchestrator:
         working_parsed = parse_model_string(model)
         working_backend = self._router.get_backend_for_model(model)
 
-        # Resolve summarizer model from summarizer_cascade[0]
-        summarizer_cascade = self._router.summarizer_cascade()
-        summarizer_model_str = summarizer_cascade[0] if summarizer_cascade else ""
-        summarizer_parsed = parse_model_string(summarizer_model_str)
-        summarizer_backend = self._router.get_backend_for_model(summarizer_model_str)
-
         context_manager = ContextManager(
             config=self.config,
             paths=repo_paths or self.paths,
-            coder_model=working_parsed.model,
-            coder_backend=working_backend,
-            summarizer_backend=summarizer_backend,
-            summarizer_model=summarizer_parsed.model,
+            working_model=working_parsed.model,
+            working_backend=working_backend,
+            router=self._router,
+            availability_cache=self._availability_cache,
         )
         comms_manager = get_manager()
 

--- a/src/matrixmouse/orchestrator.py
+++ b/src/matrixmouse/orchestrator.py
@@ -32,13 +32,15 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from matrixmouse.agents import agent_for_role
 from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, RepoPaths
 from matrixmouse.context import ContextManager
 from matrixmouse.inference.base import TokenBudgetExceededError
 from matrixmouse.inference.token_budget import TokenBudgetTracker
+if TYPE_CHECKING:
+    from matrixmouse.inference.availability import BackendAvailabilityCache
 from matrixmouse.loop import AgentLoop, LoopExitReason, LoopResult
 from matrixmouse.repository.task_repository import TaskRepository
 from matrixmouse.repository.workspace_state_repository import (
@@ -495,6 +497,7 @@ class Orchestrator:
         ws_state_repo: WorkspaceStateRepository,
         graph=None,
         budget_tracker: TokenBudgetTracker | None = None,
+        availability_cache: "BackendAvailabilityCache | None" = None,
     ):
         self.config = config
         self.paths = paths
@@ -502,8 +505,9 @@ class Orchestrator:
 
         self.queue = queue
         self._ws_state_repo = ws_state_repo
-        self._router = Router(config)
+        self._router = Router(config, budget_tracker=budget_tracker)
         self._budget_tracker = budget_tracker
+        self._availability_cache = availability_cache
 
         self._exhausted_backends: set[str] = set()
         self._exhausted_backends_lock = threading.Lock()
@@ -1084,6 +1088,61 @@ class Orchestrator:
     # Task execution
     # -----------------------------------------------------------------------
 
+    def _resolve_model_for_task(self, task: Task) -> str | None:
+        """Walk the cascade for the task's role, returning the first usable model.
+
+        For each entry:
+            1. Parse the model string.
+            2. If remote and budget_tracker is set, check budget — skip if
+               exhausted. Local backends (ollama, llamacpp) have no token
+               budget; ``parsed.is_remote`` gates this check explicitly.
+            3. If availability_cache is set, check if the backend is available
+               — skip if in cooldown.
+            4. Return the first passing model string.
+
+        Returns None if all entries are exhausted.
+
+        Args:
+            task: The task to resolve a model for.
+
+        Returns:
+            First available model string, or None.
+        """
+        from matrixmouse.inference.base import TokenBudgetExceededError
+
+        cascade = self._router.cascade_for_role(task.role)
+
+        for model_string in cascade:
+            parsed = self._router.parse_model_string(model_string)
+
+            # Budget check — local backends have no token budget.
+            # `parsed.is_remote` gates this: ollama/llamacpp are always local
+            # and never hit the provider budget, even when budget_tracker is set.
+            if parsed.is_remote and self._budget_tracker is not None:
+                try:
+                    self._budget_tracker.check_budget(
+                        provider=parsed.backend,
+                        model=parsed.model,
+                    )
+                except TokenBudgetExceededError:
+                    logger.debug(
+                        "Skipping model %s — budget exhausted.", model_string,
+                    )
+                    continue
+
+            # Availability check
+            if self._availability_cache is not None:
+                if not self._availability_cache.is_available(parsed.backend):
+                    logger.debug(
+                        "Skipping model %s — backend '%s' in cooldown.",
+                        model_string, parsed.backend,
+                    )
+                    continue
+
+            return model_string
+
+        return None
+
     def _run_task(self, task: Task) -> None:
         """
         Run a single task to completion, yield, or block.
@@ -1095,25 +1154,33 @@ class Orchestrator:
         to do next based on task status after return.
         """
 
-        # --- Upfront budget check ---
-        # If the backend for this task is known-exhausted this cycle, move
-        # the task to WAITING immediately without doing any git or agent work.
-        # The backend calculates the precise wait_until from the usage window.
-        # Uses cascade[0] (most-preferred model) at this stage — full cascade
-        # walk comes in Phase 3.
-        if self._budget_tracker is not None:
-            cascade = self._router.cascade_for_role(task.role)
-            if cascade:
-                parsed = parse_model_string(cascade[0])
-                if parsed.is_remote:
-                    try:
-                        self._budget_tracker.check_budget(
-                            provider=parsed.backend,
-                            model=parsed.model,
-                        )
-                    except TokenBudgetExceededError as e:
-                        self._handle_budget_exhausted(task, e)
-                        return
+        # --- Model resolution ---
+        # Resolve model from cascade at this stage — full cascade walk.
+        # If no model is available, handle exhaustion and return.
+        resolved_model = self._resolve_model_for_task(task)
+        if resolved_model is None:
+            # No cascade entry available — fall back to old budget check
+            # for backward compatibility during transition. Full
+            # _handle_all_backends_exhausted comes in Phase 3C.
+            if self._budget_tracker is not None:
+                cascade = self._router.cascade_for_role(task.role)
+                if cascade:
+                    parsed = parse_model_string(cascade[0])
+                    if parsed.is_remote:
+                        try:
+                            self._budget_tracker.check_budget(
+                                provider=parsed.backend,
+                                model=parsed.model,
+                            )
+                        except TokenBudgetExceededError as e:
+                            self._handle_budget_exhausted(task, e)
+                            return
+            logger.warning(
+                "Task [%s]: no model available from cascade. "
+                "Marking READY.", task.id,
+            )
+            self.queue.mark_ready(task.id)
+            return
 
         if task.branch and task.repo:
             repo_root = self.paths.workspace_root / task.repo[0]
@@ -1233,10 +1300,6 @@ class Orchestrator:
 
         messages = self._load_or_build_messages(task, agent)
 
-        # Resolve model from cascade[0] — full cascade walk in Phase 3
-        cascade = self._router.cascade_for_role(task.role)
-        resolved_model = cascade[0] if cascade else ""
-
         self._update_status(
             role=task.role.value,
             model=resolved_model,
@@ -1247,7 +1310,7 @@ class Orchestrator:
         reconfigure_for_task(task.repo, self.paths.workspace_root)
 
         try:
-            run_result = self._run_agent(ctx, agent, messages)
+            run_result = self._run_agent(ctx, agent, messages, model=resolved_model)
         except TokenBudgetExceededError as e:
             self._handle_budget_exhausted(task, e)
             return
@@ -1305,7 +1368,7 @@ class Orchestrator:
             return
 
     def _run_agent(
-        self, ctx: TaskRunContext, agent, messages: list
+        self, ctx: TaskRunContext, agent, messages: list, model: str
     ) -> RunResult:
         """
         Construct and run the AgentLoop for a task.
@@ -1314,6 +1377,7 @@ class Orchestrator:
             ctx: TaskRunContext with task and graph.
             agent: Agent instance for the task's role.
             messages: Initial message history.
+            model: The resolved model string to use for inference.
 
         Returns:
             RunResult with loop outcome and stuck detector.
@@ -1384,11 +1448,8 @@ class Orchestrator:
                 queue=self.queue,
             )
 
-        # Select model — uses cascade[0] for all roles at this stage.
-        # MERGE role uses its cascade (which defaults to coder_cascade[-1]).
-        # Full cascade walk comes in Phase 3.
-        cascade = self._router.cascade_for_role(task.role)
-        model = cascade[0] if cascade else ""
+        # Model is already resolved and passed in — no need to re-resolve.
+        # `model` parameter contains the cascade-resolved model string.
 
         wip_commit_fn = None
         if cwd is not None and task.branch:
@@ -1463,7 +1524,7 @@ class Orchestrator:
 
         detector = StuckDetector(role=task.role)
 
-        # Resolve working model from the resolved cascade entry
+        # Resolve working model and backend from the passed model string
         working_parsed = parse_model_string(model)
         working_backend = self._router.get_backend_for_model(model)
 
@@ -1495,6 +1556,7 @@ class Orchestrator:
 
         loop = AgentLoop(
             model=working_parsed.model,
+            backend=working_backend,
             messages=messages,
             tools=tools,
             allowed_tools=agent.allowed_tools,
@@ -1512,7 +1574,6 @@ class Orchestrator:
             think=self._router.think_for_role(task.role),
             current_repo=current_repo,
             task_turn_limit=task.turn_limit,
-            backend=working_backend,
         )
 
         # If the task has pending tool calls from an interrupted turn

--- a/src/matrixmouse/orchestrator.py
+++ b/src/matrixmouse/orchestrator.py
@@ -38,7 +38,6 @@ from matrixmouse.agents import agent_for_role
 from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, RepoPaths
 from matrixmouse.context import ContextManager
 from matrixmouse.inference.base import TokenBudgetExceededError
-from matrixmouse.inference.ollama import OllamaBackend
 from matrixmouse.inference.token_budget import TokenBudgetTracker
 from matrixmouse.loop import AgentLoop, LoopExitReason, LoopResult
 from matrixmouse.repository.task_repository import TaskRepository
@@ -1100,17 +1099,21 @@ class Orchestrator:
         # If the backend for this task is known-exhausted this cycle, move
         # the task to WAITING immediately without doing any git or agent work.
         # The backend calculates the precise wait_until from the usage window.
+        # Uses cascade[0] (most-preferred model) at this stage — full cascade
+        # walk comes in Phase 3.
         if self._budget_tracker is not None:
-            parsed = self._router.parsed_model_for_role(task.role)
-            if parsed.is_remote:
-                try:
-                    self._budget_tracker.check_budget(
-                        provider=parsed.backend,
-                        model=parsed.model,
-                    )
-                except TokenBudgetExceededError as e:
-                    self._handle_budget_exhausted(task, e)
-                    return
+            cascade = self._router.cascade_for_role(task.role)
+            if cascade:
+                parsed = parse_model_string(cascade[0])
+                if parsed.is_remote:
+                    try:
+                        self._budget_tracker.check_budget(
+                            provider=parsed.backend,
+                            model=parsed.model,
+                        )
+                    except TokenBudgetExceededError as e:
+                        self._handle_budget_exhausted(task, e)
+                        return
 
         if task.branch and task.repo:
             repo_root = self.paths.workspace_root / task.repo[0]
@@ -1230,9 +1233,13 @@ class Orchestrator:
 
         messages = self._load_or_build_messages(task, agent)
 
+        # Resolve model from cascade[0] — full cascade walk in Phase 3
+        cascade = self._router.cascade_for_role(task.role)
+        resolved_model = cascade[0] if cascade else ""
+
         self._update_status(
             role=task.role.value,
-            model=self._router.model_for_role(task.role),
+            model=resolved_model,
             turns=0,
             context_messages=messages,
         )
@@ -1377,15 +1384,11 @@ class Orchestrator:
                 queue=self.queue,
             )
 
-        # Select model — merge resolution always uses the top model
-        if task.role == AgentRole.MERGE:
-            merge_model = (
-                self.config.merge_resolution_model
-                or self._router.model_for_role(AgentRole.CODER)
-            )
-            model = merge_model
-        else:
-            model = self._router.model_for_role(task.role)
+        # Select model — uses cascade[0] for all roles at this stage.
+        # MERGE role uses its cascade (which defaults to coder_cascade[-1]).
+        # Full cascade walk comes in Phase 3.
+        cascade = self._router.cascade_for_role(task.role)
+        model = cascade[0] if cascade else ""
 
         wip_commit_fn = None
         if cwd is not None and task.branch:
@@ -1459,13 +1462,24 @@ class Orchestrator:
             memory.configure(self.paths.agent_notes)
 
         detector = StuckDetector(role=task.role)
+
+        # Resolve working model from the resolved cascade entry
+        working_parsed = parse_model_string(model)
+        working_backend = self._router.get_backend_for_model(model)
+
+        # Resolve summarizer model from summarizer_cascade[0]
+        summarizer_cascade = self._router.summarizer_cascade()
+        summarizer_model_str = summarizer_cascade[0] if summarizer_cascade else ""
+        summarizer_parsed = parse_model_string(summarizer_model_str)
+        summarizer_backend = self._router.get_backend_for_model(summarizer_model_str)
+
         context_manager = ContextManager(
             config=self.config,
             paths=repo_paths or self.paths,
-            coder_model=self._router.parsed_model_for_role(task.role).model,
-            coder_backend=self._router.backend_for_role(task.role),
-            summarizer_backend=self._router.backend_for_role(task.role),
-            summarizer_model=parse_model_string(self.config.summarizer_model).model,
+            coder_model=working_parsed.model,
+            coder_backend=working_backend,
+            summarizer_backend=summarizer_backend,
+            summarizer_model=summarizer_parsed.model,
         )
         comms_manager = get_manager()
 
@@ -1480,7 +1494,7 @@ class Orchestrator:
                 )
 
         loop = AgentLoop(
-            model=self._router.parsed_model_for_role(task.role).model,
+            model=working_parsed.model,
             messages=messages,
             tools=tools,
             allowed_tools=agent.allowed_tools,
@@ -1498,7 +1512,7 @@ class Orchestrator:
             think=self._router.think_for_role(task.role),
             current_repo=current_repo,
             task_turn_limit=task.turn_limit,
-            backend=OllamaBackend(),         # TODO: Have this injected
+            backend=working_backend,
         )
 
         # If the task has pending tool calls from an interrupted turn

--- a/src/matrixmouse/router.py
+++ b/src/matrixmouse/router.py
@@ -287,79 +287,6 @@ class Router:
         return self._get_or_create_backend(parsed)
 
     # -----------------------------------------------------------------------
-    # Model selection (backward-compat shims — removed in Phase 1C)
-    # -----------------------------------------------------------------------
-
-    def model_for_role(self, role: AgentRole) -> str:
-        """Return the full model string for a given agent role.
-
-        Shim: returns the first entry of the cascade list for the role.
-        This preserves backward compatibility during the transition.
-        """
-        # Handle non-AgentRole values (e.g. string from legacy call sites)
-        if not isinstance(role, AgentRole):
-            coder_cascade = self._role_cascades.get(AgentRole.CODER.value, [])
-            if coder_cascade:
-                return coder_cascade[0]
-            logger.warning(
-                "model_for_role called with non-AgentRole %r — no cascade found.",
-                role,
-            )
-            return ""
-
-        cascade = self._role_cascades.get(role.value, [])
-        if cascade:
-            return cascade[0]
-
-        # Fallback for unknown roles
-        coder_cascade = self._role_cascades.get(AgentRole.CODER.value, [])
-        if coder_cascade:
-            return coder_cascade[0]
-
-        logger.warning(
-            "model_for_role called with unknown role %r — no cascade found.",
-            role,
-        )
-        return ""
-
-    def parsed_model_for_role(self, role: AgentRole) -> ParsedModel:
-        """Return the parsed model descriptor for a given agent role."""
-        return parse_model_string(self.model_for_role(role))
-
-    def backend_for_role(self, role: AgentRole) -> LLMBackend:
-        """Return the cached ``LLMBackend`` instance for a given agent role."""
-        model_string = self.model_for_role(role)
-        return self.get_backend_for_model(model_string)
-
-    def local_model_for_role(self, model_string: str) -> str:
-        """Extract the backend-local model identifier from a full model string."""
-        return parse_model_string(model_string).model
-
-    def get_backend(self, model_string: str) -> LLMBackend:
-        """Return the cached backend for an arbitrary model string.
-
-        Shim: alias for ``get_backend_for_model``.
-        """
-        return self.get_backend_for_model(model_string)
-
-    @property
-    def current_tier(self) -> int:
-        """Current position in the Coder cascade (0 = first entry).
-
-        Shim: always returns 0 since the router no longer tracks tier state.
-        Callers should use ``cascade_for_role`` directly instead.
-        """
-        return 0
-
-    @property
-    def at_ceiling(self) -> bool:
-        """True if the Coder is at the top of the cascade.
-
-        Shim: always returns True since there is no escalation state anymore.
-        """
-        return True
-
-    # -----------------------------------------------------------------------
     # Role-derived flags (unchanged from pre-#32)
     # -----------------------------------------------------------------------
 
@@ -466,26 +393,6 @@ class Router:
         }
 
         return [system_msg, instruction_msg, handoff_msg] + list(recent)
-
-    # -----------------------------------------------------------------------
-    # Backward-compat: escalate / record_success (no-ops, removed in 1C)
-    # -----------------------------------------------------------------------
-
-    def escalate(self, detector: StuckDetector) -> tuple[bool, str | None]:
-        """Shim: no longer escalates. Returns (False, None).
-
-        The actual escalation logic has moved to the orchestrator which
-        walks the cascade directly. This shim prevents crashes during
-        the transition.
-        """
-        logger.warning(
-            "Router.escalate() is deprecated — escalation now handled by "
-            "the orchestrator's cascade walk.",
-        )
-        return False, None
-
-    def record_success(self) -> None:
-        """Shim: no-op. De-escalation state has been removed."""
 
     # -----------------------------------------------------------------------
     # Internal helpers

--- a/src/matrixmouse/router.py
+++ b/src/matrixmouse/router.py
@@ -8,25 +8,26 @@ Responsibilities:
     - Parsing ``[host:]backend:model`` model strings from config
     - Instantiating and caching ``LLMBackend`` instances (one per host+backend)
     - Enforcing the ``local_only`` safety flag at startup
-    - Assigning models to roles based on config
-    - Maintaining the cascade ladder for Coder escalation
-    - Escalating to the next model tier when stuck.py signals a stuck state
+    - Providing cascade lists for every role via ``cascade_for_role()``
+    - Providing the summarizer cascade via ``summarizer_cascade()``
+    - Vending backend instances via ``get_backend_for_model()``
+    - Validating all cascade entries at init time
+    - Ensuring only first (most-preferred) entries at startup
     - Constructing a clean handoff context when escalating
-    - Gradually de-escalating after successful cycles
+    - Injecting ``TokenBudgetTracker`` into remote backends
 
-Role-to-model mapping:
-    MANAGER  → config.manager_model  (largest, most capable)
-    CODER    → config.coder_cascade  (escalating ladder)
-    WRITER   → config.writer_model
-    CRITIC   → config.critic_model   (strong reasoning)
-    MERGE    → config.merge_resolution_model (defaults to top of coder_cascade)
-    internal summarization → config.summarizer_model (not agent-facing)
+Cascade lists:
+    Defined by config per-role (manager_cascade, critic_cascade, writer_cascade,
+    coder_cascade, merge_resolution_cascade, summarizer_cascade).  All roles
+    share the same cascade semantics — ordered preference, most-preferred first.
 
-Cascade ladder:
-    Defined by config.coder_cascade (list, smallest to largest).
-    Applies to CODER role only. All other roles use a fixed model
-    with no escalation — if Manager or Critic is stuck, the task
-    escalates to BLOCKED_BY_HUMAN rather than a larger model.
+Role-to-model mapping (via cascade):
+    MANAGER  → config.manager_cascade
+    CRITIC   → config.critic_cascade
+    WRITER   → config.writer_cascade
+    CODER    → config.coder_cascade
+    MERGE    → config.merge_resolution_cascade (defaults to [coder_cascade[-1]])
+    summarizer → config.summarizer_cascade
 
 Model string format:
     [host:]backend:model
@@ -52,14 +53,20 @@ so it is safe for concurrent access from multiple worker threads (#15).
 Do not add inference logic or tool dispatch here.
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from matrixmouse.config import MatrixMouseConfig
 from matrixmouse.inference.base import LLMBackend, Tool
 from matrixmouse.stuck import StuckDetector
 from matrixmouse.task import AgentRole
+
+if TYPE_CHECKING:
+    from matrixmouse.inference.token_budget import TokenBudgetTracker
 
 logger = logging.getLogger(__name__)
 
@@ -189,29 +196,11 @@ def _default_host(backend: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Handoff context
-# ---------------------------------------------------------------------------
-
-@dataclass
-class EscalationHandoff:
-    """Context passed to the larger model when escalating within the cascade.
-
-    Summarises what the smaller model tried and why it failed so the
-    larger model does not repeat the same mistakes.
-    """
-    from_model: str
-    to_model: str
-    stuck_summary: dict
-    recent_messages: list
-    original_messages: list
-
-
-# ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
 
 class Router:
-    """Selects models and backends for each agent role; manages escalation.
+    """Selects models and backends for each agent role; manages cascade resolution.
 
     Instantiated once by the orchestrator at startup. Backend instances are
     created lazily on first use and cached for the lifetime of the router.
@@ -223,124 +212,159 @@ class Router:
     ``config.local_only`` is ``True``, ``ValueError`` is raised immediately
     so the misconfiguration is caught at startup rather than at first
     inference call.
-
-    Escalation applies to CODER only. Manager and Critic use fixed models;
-    if they cannot complete their work within the turn limit the task moves
-    to BLOCKED_BY_HUMAN.
     """
 
-    # Number of successful Coder cycles before stepping down one cascade tier.
-    DEESCALATE_AFTER = 2
-
-    def __init__(self, config: MatrixMouseConfig) -> None:
+    def __init__(
+        self,
+        config: MatrixMouseConfig,
+        budget_tracker: TokenBudgetTracker | None = None,
+    ) -> None:
         self.config = config
+        self._budget_tracker = budget_tracker
         self._backend_cache: dict[tuple[str, str], LLMBackend] = {}
         self._cache_lock = threading.Lock()
 
-        self._cascade = self._build_cascade()
-        self._current_tier = 0
-        self._successful_cycles = 0
+        # Build and cache all role cascades at init time
+        self._role_cascades: dict[str, list[str]] = {}
+        for role in AgentRole:
+            self._role_cascades[role.value] = self._build_cascade_for_role(role)
 
-        # Validate all configured model strings and enforce local_only.
+        # Build summarizer cascade separately (not an AgentRole)
+        self._role_cascades["_summarizer"] = self._build_summarizer_cascade()
+
+        # Validate all cascade entries and enforce local_only
         self._validate_config()
 
         logger.info(
-            "Router initialised. Cascade: %s. Manager: %s. "
-            "Critic: %s. Writer: %s. Summarizer: %s. local_only: %s.",
-            self._cascade,
-            config.manager_model,
-            config.critic_model,
-            config.writer_model,
-            config.summarizer_model,
+            "Router initialised. local_only=%s, budget_tracker=%s.",
             config.local_only,
+            budget_tracker is not None,
         )
 
     # -----------------------------------------------------------------------
-    # Model selection
+    # Cascade accessors
     # -----------------------------------------------------------------------
 
-    def model_for_role(self, role: AgentRole) -> str:
-        """Return the full model string for a given agent role.
+    def cascade_for_role(self, role: AgentRole) -> list[str]:
+        """Return the ordered cascade list for the given role.
 
-        The returned string is the raw config value — use
-        ``parsed_model_for_role`` or ``backend_for_role`` when you need
-        to pass it to an inference backend.
-
-        Args:
-            role: The AgentRole of the running agent.
-
-        Returns:
-            Model string, e.g. ``"ollama:qwen3:4b"``.
-        """
-        if role == AgentRole.MANAGER:
-            return self.config.manager_model
-        if role == AgentRole.CRITIC:
-            return self.config.critic_model
-        if role == AgentRole.CODER:
-            return self._current_model()
-        if role == AgentRole.WRITER:
-            return self.config.writer_model
-        if role == AgentRole.MERGE:
-            return self._merge_model()
-
-        logger.warning(
-            "model_for_role called with unknown role %r — "
-            "falling back to coder_model.",
-            role,
-        )
-        return self.config.coder_model
-
-    def parsed_model_for_role(self, role: AgentRole) -> ParsedModel:
-        """Return the parsed model descriptor for a given agent role.
+        Always returns at least one entry. Raises ValueError at init time
+        if a required cascade is empty or missing.
 
         Args:
-            role: The AgentRole of the running agent.
+            role: The AgentRole to get the cascade for.
 
         Returns:
-            ``ParsedModel`` with host, backend, and model identifier.
+            Ordered list of model strings, most-preferred first.
         """
-        return parse_model_string(self.model_for_role(role))
+        return list(self._role_cascades[role.value])
 
-    def backend_for_role(self, role: AgentRole) -> LLMBackend:
-        """Return the cached ``LLMBackend`` instance for a given agent role.
+    def summarizer_cascade(self) -> list[str]:
+        """Return the ordered cascade list for the summarizer.
 
-        Instantiates the backend on first call for this (host, backend) pair.
-        Subsequent calls return the cached instance.
-
-        Args:
-            role: The AgentRole of the running agent.
+        Named separately from cascade_for_role to keep AgentRole clean.
 
         Returns:
-            ``LLMBackend`` ready for ``chat()`` calls.
-
-        Raises:
-            ValueError: If the backend identifier is not recognised.
+            Ordered list of model strings, most-preferred first.
         """
-        parsed = self.parsed_model_for_role(role)
-        return self._get_or_create_backend(parsed)
+        return list(self._role_cascades["_summarizer"])
 
-    def local_model_for_role(self, model_string: str) -> str:
-        """Extract the backend-local model identifier from a full model string.
+    def get_backend_for_model(self, model_string: str) -> LLMBackend:
+        """Return the cached LLMBackend for an arbitrary model string.
 
-        This is the portion passed to ``LLMBackend.chat(model=...)``.
+        Single entry point for all backend access after cascade resolution.
+        Backends are instantiated with budget_tracker if one is configured —
+        token usage is recorded automatically by the adapter on every
+        successful chat() call, regardless of caller.
 
         Args:
             model_string: Full model string, e.g. ``"ollama:qwen3:4b"``.
 
         Returns:
-            Backend-local model identifier, e.g. ``"qwen3:4b"``.
+            Cached ``LLMBackend`` instance.
         """
+        parsed = parse_model_string(model_string)
+        return self._get_or_create_backend(parsed)
+
+    # -----------------------------------------------------------------------
+    # Model selection (backward-compat shims — removed in Phase 1C)
+    # -----------------------------------------------------------------------
+
+    def model_for_role(self, role: AgentRole) -> str:
+        """Return the full model string for a given agent role.
+
+        Shim: returns the first entry of the cascade list for the role.
+        This preserves backward compatibility during the transition.
+        """
+        # Handle non-AgentRole values (e.g. string from legacy call sites)
+        if not isinstance(role, AgentRole):
+            coder_cascade = self._role_cascades.get(AgentRole.CODER.value, [])
+            if coder_cascade:
+                return coder_cascade[0]
+            logger.warning(
+                "model_for_role called with non-AgentRole %r — no cascade found.",
+                role,
+            )
+            return ""
+
+        cascade = self._role_cascades.get(role.value, [])
+        if cascade:
+            return cascade[0]
+
+        # Fallback for unknown roles
+        coder_cascade = self._role_cascades.get(AgentRole.CODER.value, [])
+        if coder_cascade:
+            return coder_cascade[0]
+
+        logger.warning(
+            "model_for_role called with unknown role %r — no cascade found.",
+            role,
+        )
+        return ""
+
+    def parsed_model_for_role(self, role: AgentRole) -> ParsedModel:
+        """Return the parsed model descriptor for a given agent role."""
+        return parse_model_string(self.model_for_role(role))
+
+    def backend_for_role(self, role: AgentRole) -> LLMBackend:
+        """Return the cached ``LLMBackend`` instance for a given agent role."""
+        model_string = self.model_for_role(role)
+        return self.get_backend_for_model(model_string)
+
+    def local_model_for_role(self, model_string: str) -> str:
+        """Extract the backend-local model identifier from a full model string."""
         return parse_model_string(model_string).model
 
-    def stream_for_role(self, role: AgentRole) -> bool:
-        """Return whether to stream model output for a given role.
+    def get_backend(self, model_string: str) -> LLMBackend:
+        """Return the cached backend for an arbitrary model string.
 
-        Args:
-            role: The AgentRole of the running agent.
-
-        Returns:
-            ``True`` if streaming should be enabled.
+        Shim: alias for ``get_backend_for_model``.
         """
+        return self.get_backend_for_model(model_string)
+
+    @property
+    def current_tier(self) -> int:
+        """Current position in the Coder cascade (0 = first entry).
+
+        Shim: always returns 0 since the router no longer tracks tier state.
+        Callers should use ``cascade_for_role`` directly instead.
+        """
+        return 0
+
+    @property
+    def at_ceiling(self) -> bool:
+        """True if the Coder is at the top of the cascade.
+
+        Shim: always returns True since there is no escalation state anymore.
+        """
+        return True
+
+    # -----------------------------------------------------------------------
+    # Role-derived flags (unchanged from pre-#32)
+    # -----------------------------------------------------------------------
+
+    def stream_for_role(self, role: AgentRole) -> bool:
+        """Return whether to stream model output for a given role."""
         if role == AgentRole.MANAGER:
             return self.config.manager_stream
         if role == AgentRole.CRITIC:
@@ -352,14 +376,7 @@ class Router:
         return True
 
     def think_for_role(self, role: AgentRole) -> bool:
-        """Return whether to enable extended thinking for a given role.
-
-        Args:
-            role: The AgentRole of the running agent.
-
-        Returns:
-            ``True`` if extended thinking should be enabled.
-        """
+        """Return whether to enable extended thinking for a given role."""
         if role == AgentRole.MANAGER:
             return self.config.manager_think
         if role == AgentRole.CRITIC:
@@ -375,30 +392,23 @@ class Router:
     # -----------------------------------------------------------------------
 
     def ensure_all_models(self) -> None:
-        """Verify all configured models are available on their backends.
+        """Verify the first (most-preferred) entry in each cascade is available.
 
-        Calls ``backend.ensure_model()`` for every configured model string,
-        deduplicating by (backend_instance, model_id) so the same model
-        served by the same backend is only checked once.
-
-        Called once during the service startup sequence in ``_service.py``,
-        after the Router is constructed and ``_validate_config()`` has
-        already confirmed all model strings are well-formed.
+        Calls ``backend.ensure_model()`` for cascade[0] of every role
+        plus cascade[0] of summarizer, deduplicating by (backend_instance,
+        model_id).
 
         Raises:
             ModelNotAvailableError: If a model cannot be made available.
             BackendConnectionError: If a backend cannot be reached.
         """
-        all_model_strings = [
-            self.config.manager_model,
-            self.config.critic_model,
-            self.config.writer_model,
-            self.config.summarizer_model,
-            self._merge_model(),
-        ] + list(self._cascade)
+        model_strings: list[str] = []
+        for cascade in self._role_cascades.values():
+            if cascade:
+                model_strings.append(cascade[0])
 
         seen: set[tuple[int, str]] = set()
-        for model_string in all_model_strings:
+        for model_string in model_strings:
             if not model_string:
                 continue
             parsed = parse_model_string(model_string)
@@ -413,157 +423,9 @@ class Router:
             )
             backend.ensure_model(parsed.model)
 
-    def get_backend(self, model_string: str) -> LLMBackend:
-        """Return the cached backend for an arbitrary model string.
-
-        Useful for the summarizer model and other non-role inference calls.
-
-        Args:
-            model_string: Full model string, e.g. ``"ollama:qwen3:4b"``.
-
-        Returns:
-            Cached ``LLMBackend`` instance.
-        """
-        parsed = parse_model_string(model_string)
-        return self._get_or_create_backend(parsed)
-
-    def _get_or_create_backend(self, parsed: ParsedModel) -> LLMBackend:
-        """Return a cached backend or instantiate a new one.
-
-        Cache key is ``(host, backend)`` — one instance per endpoint,
-        regardless of which model is requested from it.
-
-        Args:
-            parsed: Parsed model descriptor.
-
-        Returns:
-            ``LLMBackend`` instance.
-        """
-        cache_key = (parsed.host, parsed.backend)
-        with self._cache_lock:
-            if cache_key in self._backend_cache:
-                return self._backend_cache[cache_key]
-            backend = self._instantiate_backend(parsed)
-            self._backend_cache[cache_key] = backend
-            logger.debug(
-                "Backend instantiated and cached: %s @ %s",
-                parsed.backend, parsed.host,
-            )
-            return backend
-
-    def _instantiate_backend(self, parsed: ParsedModel) -> LLMBackend:
-        """Construct a new ``LLMBackend`` instance for the given parsed model.
-
-        Args:
-            parsed: Parsed model descriptor.
-
-        Returns:
-            New ``LLMBackend`` instance.
-
-        Raises:
-            ValueError: If the backend identifier is not recognised or
-                the required API key is missing.
-        """
-        backend = parsed.backend
-
-        if backend == "ollama":
-            from matrixmouse.inference.ollama import OllamaBackend
-            return OllamaBackend(host=parsed.host)
-
-        if backend == "llamacpp":
-            from matrixmouse.inference.llamacpp import LlamaCppBackend
-            return LlamaCppBackend(host=parsed.host)
-
-        if backend == "anthropic":
-            import os
-            api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-            if not api_key:
-                raise ValueError(
-                    "ANTHROPIC_API_KEY is not set. "
-                    "Place the key in /etc/matrixmouse/secrets/anthropic_api_key "
-                    "and ensure _service.py loads it into the environment."
-                )
-            from matrixmouse.inference.anthropic import AnthropicBackend
-            return AnthropicBackend(api_key=api_key)
-
-        if backend == "openai":
-            import os
-            api_key = os.environ.get("OPENAI_API_KEY", "")
-            if not api_key:
-                raise ValueError(
-                    "OPENAI_API_KEY is not set. "
-                    "Place the key in /etc/matrixmouse/secrets/openai_api_key "
-                    "and ensure _service.py loads it into the environment."
-                )
-            from matrixmouse.inference.openai import OpenAIBackend
-            return OpenAIBackend(api_key=api_key, base_url=parsed.host)
-
-        raise ValueError(
-            f"Unknown backend '{backend}'. "
-            f"Known backends: {sorted(_KNOWN_BACKENDS)}"
-        )
-
     # -----------------------------------------------------------------------
-    # Cascade escalation (Coder only)
+    # Handoff construction (kept unchanged)
     # -----------------------------------------------------------------------
-
-    def escalate(self, detector: StuckDetector) -> tuple[bool, str | None]:
-        """Attempt to escalate the Coder to the next cascade tier.
-
-        Only applies to the Coder role. Manager and Critic do not
-        escalate — they move to BLOCKED_BY_HUMAN at their turn limit.
-
-        Args:
-            detector: StuckDetector from the failed loop run.
-
-        Returns:
-            ``(escalated, new_model_string)`` — ``escalated`` is False if
-            already at the top of the cascade.
-        """
-        if self._current_tier >= len(self._cascade) - 1:
-            logger.warning(
-                "Escalation requested but already at top of cascade (%s). "
-                "Human intervention required.",
-                self._current_model(),
-            )
-            return False, None
-
-        old_model = self._current_model()
-        self._current_tier += 1
-        new_model = self._current_model()
-        self._successful_cycles = 0
-
-        logger.info(
-            "Escalating Coder: %s → %s. Stuck reason: %s",
-            old_model, new_model, detector.last_reason,
-        )
-        return True, new_model
-
-    def record_success(self) -> None:
-        """Record a successful Coder cycle toward de-escalation.
-
-        After ``DEESCALATE_AFTER`` consecutive successes, step down one
-        cascade tier. Call this from the orchestrator when a Coder task
-        completes cleanly.
-        """
-        if self._current_tier == 0:
-            return
-
-        self._successful_cycles += 1
-        logger.debug(
-            "Successful Coder cycle recorded (%d/%d toward de-escalation).",
-            self._successful_cycles, self.DEESCALATE_AFTER,
-        )
-
-        if self._successful_cycles >= self.DEESCALATE_AFTER:
-            old_model = self._current_model()
-            self._current_tier = max(0, self._current_tier - 1)
-            new_model = self._current_model()
-            self._successful_cycles = 0
-            logger.info(
-                "De-escalating Coder after %d successful cycles: %s → %s.",
-                self.DEESCALATE_AFTER, old_model, new_model,
-            )
 
     def build_handoff(
         self,
@@ -571,16 +433,7 @@ class Router:
         messages: list,
         keep_recent: int = 6,
     ) -> list:
-        """Build a clean starting message history for the escalated model.
-
-        Args:
-            detector: StuckDetector with diagnostics from the failed run.
-            messages: Full message history from the failed run.
-            keep_recent: Number of recent messages to include verbatim.
-
-        Returns:
-            Trimmed message list ready to pass to AgentLoop.
-        """
+        """Build a clean starting message history for the escalated model."""
         if len(messages) < 2:
             return messages
 
@@ -614,52 +467,200 @@ class Router:
 
         return [system_msg, instruction_msg, handoff_msg] + list(recent)
 
-    @property
-    def current_tier(self) -> int:
-        """Current position in the Coder cascade (0 = smallest model)."""
-        return self._current_tier
+    # -----------------------------------------------------------------------
+    # Backward-compat: escalate / record_success (no-ops, removed in 1C)
+    # -----------------------------------------------------------------------
 
-    @property
-    def at_ceiling(self) -> bool:
-        """True if the Coder is already at the top of the cascade."""
-        return self._current_tier >= len(self._cascade) - 1
+    def escalate(self, detector: StuckDetector) -> tuple[bool, str | None]:
+        """Shim: no longer escalates. Returns (False, None).
+
+        The actual escalation logic has moved to the orchestrator which
+        walks the cascade directly. This shim prevents crashes during
+        the transition.
+        """
+        logger.warning(
+            "Router.escalate() is deprecated — escalation now handled by "
+            "the orchestrator's cascade walk.",
+        )
+        return False, None
+
+    def record_success(self) -> None:
+        """Shim: no-op. De-escalation state has been removed."""
 
     # -----------------------------------------------------------------------
     # Internal helpers
     # -----------------------------------------------------------------------
 
-    def _validate_config(self) -> None:
-        """Parse all configured model strings and enforce local_only.
+    def _get_or_create_backend(self, parsed: ParsedModel) -> LLMBackend:
+        """Return a cached backend or instantiate a new one.
 
-        Called once at construction time. Raises immediately if any model
-        string is malformed or if a remote backend is configured while
+        Cache key is ``(host, backend)`` — one instance per endpoint.
+        """
+        cache_key = (parsed.host, parsed.backend)
+        with self._cache_lock:
+            if cache_key in self._backend_cache:
+                return self._backend_cache[cache_key]
+            backend = self._instantiate_backend(parsed)
+            self._backend_cache[cache_key] = backend
+            logger.debug(
+                "Backend instantiated and cached: %s @ %s",
+                parsed.backend, parsed.host,
+            )
+            return backend
+
+    def _instantiate_backend(self, parsed: ParsedModel) -> LLMBackend:
+        """Construct a new ``LLMBackend`` instance for the given parsed model."""
+        backend = parsed.backend
+
+        if backend == "ollama":
+            from matrixmouse.inference.ollama import OllamaBackend
+            return OllamaBackend(host=parsed.host)
+
+        if backend == "llamacpp":
+            from matrixmouse.inference.llamacpp import LlamaCppBackend
+            return LlamaCppBackend(host=parsed.host)
+
+        if backend == "anthropic":
+            import os
+            api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+            if not api_key:
+                raise ValueError(
+                    "ANTHROPIC_API_KEY is not set. "
+                    "Place the key in /etc/matrixmouse/secrets/anthropic_api_key "
+                    "and ensure _service.py loads it into the environment."
+                )
+            from matrixmouse.inference.anthropic import AnthropicBackend
+            return AnthropicBackend(
+                api_key=api_key,
+                budget_tracker=self._budget_tracker,
+            )
+
+        if backend == "openai":
+            import os
+            api_key = os.environ.get("OPENAI_API_KEY", "")
+            if not api_key:
+                raise ValueError(
+                    "OPENAI_API_KEY is not set. "
+                    "Place the key in /etc/matrixmouse/secrets/openai_api_key "
+                    "and ensure _service.py loads it into the environment."
+                )
+            from matrixmouse.inference.openai import OpenAIBackend
+            return OpenAIBackend(
+                api_key=api_key,
+                base_url=parsed.host,
+                budget_tracker=self._budget_tracker,
+            )
+
+        raise ValueError(
+            f"Unknown backend '{backend}'. "
+            f"Known backends: {sorted(_KNOWN_BACKENDS)}"
+        )
+
+    def _build_cascade_for_role(self, role: AgentRole) -> list[str]:
+        """Build the ordered cascade list for a role from config.
+
+        Merge role defaults to [coder_cascade[-1]] if unconfigured.
+        Raises ValueError if a required cascade is empty.
+
+        Args:
+            role: The AgentRole to build the cascade for.
+
+        Returns:
+            Non-empty list of model strings.
+
+        Raises:
+            ValueError: If the cascade is empty after resolving defaults.
+        """
+        role_to_config_key: dict[AgentRole, str] = {
+            AgentRole.MANAGER:  "manager_cascade",
+            AgentRole.CRITIC:   "critic_cascade",
+            AgentRole.WRITER:   "writer_cascade",
+            AgentRole.CODER:    "coder_cascade",
+            AgentRole.MERGE:    "merge_resolution_cascade",
+        }
+
+        config_key = role_to_config_key.get(role)
+        if config_key is None:
+            raise ValueError(f"Unknown role: {role}")
+
+        cascade = list(getattr(self.config, config_key, []))
+
+        # Default: merge_resolution_cascade falls back to [coder_cascade[-1]]
+        if role == AgentRole.MERGE and not cascade:
+            coder_cascade = list(self.config.coder_cascade or [])
+            if coder_cascade:
+                cascade = [coder_cascade[-1]]
+
+        if not cascade:
+            raise ValueError(
+                f"Required cascade '{config_key}' is empty. "
+                f"Configure it in config.toml."
+            )
+
+        logger.info("%s cascade: %s", config_key, cascade)
+        return cascade
+
+    def _build_summarizer_cascade(self) -> list[str]:
+        """Build the summarizer cascade from config.
+
+        Summarizer is not an AgentRole, so it's handled separately.
+
+        Returns:
+            Non-empty list of model strings.
+
+        Raises:
+            ValueError: If summarizer_cascade is empty.
+        """
+        cascade = list(self.config.summarizer_cascade or [])
+        if not cascade:
+            raise ValueError(
+                "Required cascade 'summarizer_cascade' is empty. "
+                "Configure it in config.toml."
+            )
+        logger.info("summarizer_cascade: %s", cascade)
+        return cascade
+
+    def _validate_config(self) -> None:
+        """Parse all cascade entries and enforce local_only.
+
+        Called once at construction time. Raises immediately if any entry
+        is malformed, empty, or if a remote backend is configured while
         ``local_only`` is ``True``.
 
         Raises:
-            ValueError: On any malformed model string or local_only violation.
+            ValueError: On any malformed/empty entry or local_only violation.
         """
-        all_model_strings = [
-            ("manager_model",    self.config.manager_model),
-            ("critic_model",     self.config.critic_model),
-            ("writer_model",     self.config.writer_model),
-            ("summarizer_model", self.config.summarizer_model),
-        ]
-        for i, model_string in enumerate(self._cascade):
-            all_model_strings.append((f"coder_cascade[{i}]", model_string))
+        # Map internal cascade keys to their config key names for error messages
+        key_map: dict[str, str] = {
+            AgentRole.MANAGER.value:  "manager_cascade",
+            AgentRole.CRITIC.value:   "critic_cascade",
+            AgentRole.WRITER.value:   "writer_cascade",
+            AgentRole.CODER.value:    "coder_cascade",
+            AgentRole.MERGE.value:    "merge_resolution_cascade",
+            "_summarizer":             "summarizer_cascade",
+        }
 
-        merge_model = self._merge_model()
-        all_model_strings.append(("merge_resolution_model", merge_model))
+        # Collect all cascade entries with their config key names
+        all_entries: list[tuple[str, str]] = []  # (config_key, model_string)
+
+        for cascade_key, cascade in self._role_cascades.items():
+            config_key_base = key_map.get(cascade_key, cascade_key)
+            for i, model_string in enumerate(cascade):
+                all_entries.append((f"{config_key_base}[{i}]", model_string))
 
         remote_violations: list[str] = []
 
-        for config_key, model_string in all_model_strings:
+        for config_key, model_string in all_entries:
             if not model_string:
-                continue
+                raise ValueError(
+                    f"Empty model string at {config_key}. "
+                    f"Every cascade entry must be a valid model string."
+                )
             try:
                 parsed = parse_model_string(model_string)
             except ValueError as e:
                 raise ValueError(
-                    f"Invalid model string for {config_key}: {e}"
+                    f"Invalid model string at {config_key}: {e}"
                 ) from e
 
             if self.config.local_only and parsed.is_remote:
@@ -675,36 +676,4 @@ class Router:
                 + "\n\nEither set local_only = false or use only local "
                 "backends (ollama, llamacpp)."
             )
-
-    def _build_cascade(self) -> list[str]:
-        """Build the ordered Coder cascade ladder from config.
-
-        If ``config.coder_cascade`` is set, use it directly. Otherwise
-        fall back to a single-tier ladder containing only
-        ``config.coder_model`` — escalation is effectively disabled.
-        """
-        if self.config.coder_cascade:
-            cascade = list(self.config.coder_cascade)
-            logger.info("Coder cascade ladder: %s", cascade)
-            return cascade
-
-        logger.info(
-            "No coder_cascade configured. Single-tier Coder ladder: [%s]. "
-            "Set coder_cascade in config.toml to enable escalation.",
-            self.config.coder_model,
-        )
-        return [self.config.coder_model]
-
-    def _current_model(self) -> str:
-        """Return the full model string at the current Coder cascade tier."""
-        return self._cascade[self._current_tier]
-
-    def _merge_model(self) -> str:
-        """Return the model string for the Merge role.
-
-        Defaults to the top of the Coder cascade if not explicitly configured.
-        """
-        if self.config.merge_resolution_model:
-            return self.config.merge_resolution_model
-        return self._cascade[-1] if self._cascade else self.config.coder_model
     

--- a/src/matrixmouse/tools/__init__.py
+++ b/src/matrixmouse/tools/__init__.py
@@ -47,7 +47,7 @@ Tool schema convention:
     raw callables.  Any call site that was previously iterating the result as
     plain functions must be updated to access ``tool.fn`` for dispatch and
     ``tool.schema`` for schema extraction.  The primary call site is
-    ``loop.py`` — this is a known Phase 2 update.
+    ``loop.py``.
 
 Submodules:
     file_tools       — read, write, str_replace, append

--- a/tests/inference/test_availability.py
+++ b/tests/inference/test_availability.py
@@ -1,0 +1,279 @@
+"""
+tests/inference/test_availability.py
+
+Tests for BackendAvailabilityCache — Issue #32.
+
+All tests use InMemoryWorkspaceStateRepository.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from matrixmouse.inference.availability import BackendAvailabilityCache
+from matrixmouse.repository.memory_workspace_state_repository import (
+    InMemoryWorkspaceStateRepository,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_cache(
+    initial: int = 30,
+    maximum: int = 600,
+) -> tuple[BackendAvailabilityCache, InMemoryWorkspaceStateRepository]:
+    """Create a fresh cache + repo pair."""
+    repo = InMemoryWorkspaceStateRepository()
+    cache = BackendAvailabilityCache(
+        ws_state_repo=repo,
+        initial_cooldown_seconds=initial,
+        max_cooldown_seconds=maximum,
+    )
+    return cache, repo
+
+
+# ---------------------------------------------------------------------------
+# Basic availability
+# ---------------------------------------------------------------------------
+
+class TestAvailabilityBasic:
+    def test_is_available_no_record(self):
+        """True with no history."""
+        cache, _ = make_cache()
+        assert cache.is_available("anthropic") is True
+
+    def test_is_available_during_cooldown(self):
+        """Record failure, immediately check → False."""
+        cache, _ = make_cache()
+        cache.record_failure("anthropic")
+        assert cache.is_available("anthropic") is False
+
+    def test_is_available_after_cooldown_expires(self):
+        """Mock datetime.now past cooldown_until → True."""
+        cache, _ = make_cache()
+        cache.record_failure("anthropic")
+        # Move time far into the future
+        with patch(
+            "matrixmouse.inference.availability.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime.now(timezone.utc) + timedelta(hours=1)
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            assert cache.is_available("anthropic") is True
+
+    def test_record_success_clears_state(self):
+        """Failures then success → is_available True, consecutive_failures 0."""
+        cache, repo = make_cache()
+        cache.record_failure("anthropic")
+        assert cache.is_available("anthropic") is False
+        cache.record_success("anthropic")
+        assert cache.is_available("anthropic") is True
+        record = repo.get("backend_availability:anthropic")
+        assert record is not None
+        assert record["consecutive_failures"] == 0
+
+    def test_record_success_no_record_is_noop(self):
+        """No exception when no record exists."""
+        cache, _ = make_cache()
+        cache.record_success("anthropic")  # should not raise
+        assert cache.is_available("anthropic") is True
+
+
+# ---------------------------------------------------------------------------
+# Failure recording and backoff
+# ---------------------------------------------------------------------------
+
+class TestFailureRecording:
+    def test_record_failure_first(self):
+        """First failure: consecutive_failures=1, cooldown ~= initial."""
+        cache, repo = make_cache(initial=30)
+        cache.record_failure("anthropic")
+        record = repo.get("backend_availability:anthropic")
+        assert record is not None
+        assert record["consecutive_failures"] == 1
+        assert record["cooldown_until"] is not None
+
+    def test_record_failure_exponential_backoff(self):
+        """Failures 1..5 produce 30, 60, 120, 240, 480s.
+        Failure #6 would be 960 but is capped at 600s (max)."""
+        cache, _ = make_cache(initial=30, maximum=600)
+        base = datetime(2026, 4, 2, 0, 0, 0, tzinfo=timezone.utc)
+        durations = []
+        for i in range(1, 6):
+            with patch(
+                "matrixmouse.inference.availability.datetime",
+            ) as mock_dt:
+                mock_dt.now.return_value = base
+                mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+                mock_dt.fromisoformat = datetime.fromisoformat
+                cache.record_failure("anthropic")
+            record = cache._repo.get("backend_availability:anthropic")
+            cooldown_until = datetime.fromisoformat(record["cooldown_until"])
+            durations.append((cooldown_until - base).total_seconds())
+
+        expected = [30, 60, 120, 240, 480]
+        for i, (actual, exp) in enumerate(zip(durations, expected), 1):
+            assert actual == pytest.approx(exp, abs=2), (
+                f"Failure #{i}: expected ~{exp}s, got {actual}s"
+            )
+
+    def test_record_failure_cap_does_not_exceed_max(self):
+        """6 failures: 30*2^5=960, capped at 600s."""
+        cache, _ = make_cache(initial=30, maximum=600)
+        base = datetime(2026, 4, 2, 0, 0, 0, tzinfo=timezone.utc)
+        for _ in range(6):
+            with patch(
+                "matrixmouse.inference.availability.datetime",
+            ) as mock_dt:
+                mock_dt.now.return_value = base
+                mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+                mock_dt.fromisoformat = datetime.fromisoformat
+                cache.record_failure("anthropic")
+        record = cache._repo.get("backend_availability:anthropic")
+        cooldown_until = datetime.fromisoformat(record["cooldown_until"])
+        assert (cooldown_until - base).total_seconds() == pytest.approx(600, abs=2)
+
+    def test_stale_cooldown_resets_before_increment(self):
+        """Record 3 failures (long cooldown), mock time past cooldown_until,
+        record another failure → consecutive_failures is 1 (reset to 0
+        then incremented), not 4."""
+        cache, _ = make_cache(initial=30, maximum=600)
+        base = datetime(2026, 4, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+        # Record 3 failures → cooldown = 120s
+        for _ in range(3):
+            with patch(
+                "matrixmouse.inference.availability.datetime",
+            ) as mock_dt:
+                mock_dt.now.return_value = base
+                mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+                mock_dt.fromisoformat = datetime.fromisoformat
+                cache.record_failure("anthropic")
+
+        record = cache._repo.get("backend_availability:anthropic")
+        cooldown_until = datetime.fromisoformat(record["cooldown_until"])
+
+        # Move past the cooldown
+        new_time = cooldown_until + timedelta(seconds=10)
+        with patch(
+            "matrixmouse.inference.availability.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = new_time
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            mock_dt.fromisoformat = datetime.fromisoformat
+            cache.record_failure("anthropic")
+
+        record = cache._repo.get("backend_availability:anthropic")
+        assert record["consecutive_failures"] == 1
+
+
+# ---------------------------------------------------------------------------
+# earliest_available_at
+# ---------------------------------------------------------------------------
+
+class TestEarliestAvailable:
+    def test_earliest_available_at_empty_list_returns_none(self):
+        cache, _ = make_cache()
+        assert cache.earliest_available_at([]) is None
+
+    def test_earliest_available_at_any_available_returns_none(self):
+        """One available, one not → None."""
+        cache, _ = make_cache()
+        cache.record_failure("anthropic")  # in cooldown
+        assert cache.earliest_available_at(["anthropic", "openai"]) is None
+
+    def test_earliest_available_at_all_in_cooldown_returns_minimum(self):
+        """All backends in cooldown → return the earliest (minimum) time."""
+        cache, _ = make_cache(initial=30, maximum=600)
+        base = datetime(2026, 4, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+        # anthropic: 1 failure → 30s cooldown
+        with patch(
+            "matrixmouse.inference.availability.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = base
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            mock_dt.fromisoformat = datetime.fromisoformat
+            cache.record_failure("anthropic")
+
+        # openai: 2 failures → 60s cooldown
+        with patch(
+            "matrixmouse.inference.availability.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = base
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            mock_dt.fromisoformat = datetime.fromisoformat
+            cache.record_failure("openai")
+            cache.record_failure("openai")
+
+        # Query with time still within cooldown
+        with patch(
+            "matrixmouse.inference.availability.datetime",
+        ) as mock_dt:
+            mock_dt.now.return_value = base + timedelta(seconds=10)
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            mock_dt.fromisoformat = datetime.fromisoformat
+            earliest = cache.earliest_available_at(["anthropic", "openai"])
+
+        # anthropic has the shorter cooldown (30s vs 60s)
+        assert earliest is not None
+        earliest_dt = datetime.fromisoformat(earliest)
+        # Should be ~30s after base
+        assert (earliest_dt - base).total_seconds() == pytest.approx(30, abs=2)
+
+
+# ---------------------------------------------------------------------------
+# Backend independence
+# ---------------------------------------------------------------------------
+
+class TestBackendIndependence:
+    def test_multiple_backends_independent(self):
+        """Failure on 'anthropic' doesn't affect 'ollama'."""
+        cache, _ = make_cache()
+        cache.record_failure("anthropic")
+        assert cache.is_available("anthropic") is False
+        assert cache.is_available("ollama") is True
+
+    def test_availability_cache_key_isolation(self):
+        """Write a failure record for 'anthropic', confirm
+        ws_state_repo.get('backend_availability:ollama') is None;
+        tests that storage keys are properly namespaced."""
+        cache, repo = make_cache()
+        cache.record_failure("anthropic")
+        assert repo.get("backend_availability:anthropic") is not None
+        assert repo.get("backend_availability:ollama") is None
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_persistence_across_instances(self):
+        """Record failure, create new cache instance with same repo,
+        is_available still False."""
+        cache1, repo = make_cache()
+        cache1.record_failure("anthropic")
+
+        cache2 = BackendAvailabilityCache(
+            ws_state_repo=repo,
+            initial_cooldown_seconds=30,
+            max_cooldown_seconds=600,
+        )
+        assert cache2.is_available("anthropic") is False
+
+    def test_cooldown_cleared_after_success_across_instances(self):
+        """Record 3 failures, record success, new instance shows available."""
+        cache1, repo = make_cache()
+        for _ in range(3):
+            cache1.record_failure("anthropic")
+        cache1.record_success("anthropic")
+
+        cache2 = BackendAvailabilityCache(
+            ws_state_repo=repo,
+            initial_cooldown_seconds=30,
+            max_cooldown_seconds=600,
+        )
+        assert cache2.is_available("anthropic") is True

--- a/tests/inference/test_base.py
+++ b/tests/inference/test_base.py
@@ -1,0 +1,33 @@
+"""
+tests/inference/test_base.py
+
+Tests for inference exception hierarchy, including the
+SummarizationUnavailableError added in Issue #32.
+"""
+
+import pytest
+
+from matrixmouse.inference.base import LLMBackendError, SummarizationUnavailableError
+
+
+class TestSummarizationUnavailableError:
+    """Tests for SummarizationUnavailableError — Issue #32."""
+
+    def test_summarization_unavailable_error_is_llm_backend_error(self):
+        """Must be a subclass of LLMBackendError so loop.py re-raises it."""
+        assert issubclass(SummarizationUnavailableError, LLMBackendError)
+
+    def test_summarization_unavailable_error_caught_by_base_class(self):
+        """Confirm it is caught by 'except LLMBackendError' blocks."""
+        try:
+            raise SummarizationUnavailableError("test")
+        except LLMBackendError:
+            pass  # Expected path
+        else:
+            pytest.fail("Should have been caught as LLMBackendError")
+
+    def test_summarization_unavailable_error_message(self):
+        """Confirm it has a readable message."""
+        msg = "All summarizer cascade entries are unavailable."
+        err = SummarizationUnavailableError(msg)
+        assert msg in str(err)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,8 +10,11 @@ and ensures defaults match documented behaviour.
 New keys are added here whenever a config field is introduced.
 """
 
-from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, load_config
 from pathlib import Path
+
+import pytest
+
+from matrixmouse.config import MatrixMouseConfig, MatrixMousePaths, load_config
 
 
 # ---------------------------------------------------------------------------
@@ -87,9 +90,9 @@ class TestTurnLimitConfig:
 # ---------------------------------------------------------------------------
 
 class TestWriterModelConfig:
-    def test_writer_model_accessible(self):
+    def test_writer_cascade_accessible(self):
         cfg = make_config()
-        _ = cfg.writer_model
+        _ = cfg.writer_cascade
 
     def test_writer_stream_accessible(self):
         cfg = make_config()
@@ -137,8 +140,8 @@ class TestBranchManagement:
     def test_merge_conflict_max_turns_default(self):
         assert make_config().merge_conflict_max_turns == 5
 
-    def test_merge_resolution_model_default_empty(self):
-        assert make_config().merge_resolution_model == ""
+    def test_merge_resolution_cascade_default_empty(self):
+        assert make_config().merge_resolution_cascade == []
 
     def test_push_wip_to_remote_default_false(self):
         assert make_config().push_wip_to_remote is False
@@ -184,3 +187,53 @@ class TestMatrixMousePaths:
     def test_mm_dir_property(self, tmp_path):
         paths = MatrixMousePaths(workspace_root=tmp_path)
         assert paths.mm_dir == tmp_path / ".matrixmouse"
+
+
+# ---------------------------------------------------------------------------
+# Cascade config — Issue #32
+# ---------------------------------------------------------------------------
+
+class TestCascadeConfig:
+    """All six role cascade fields exist and default to empty lists."""
+
+    def test_cascade_fields_present(self):
+        cfg = make_config()
+        assert cfg.manager_cascade == []
+        assert cfg.critic_cascade == []
+        assert cfg.writer_cascade == []
+        assert cfg.coder_cascade == []
+        assert cfg.merge_resolution_cascade == []
+        assert cfg.summarizer_cascade == []
+
+    def test_cooldown_fields_present(self):
+        cfg = make_config()
+        assert cfg.backend_cooldown_initial_seconds == 30
+        assert cfg.backend_cooldown_max_seconds == 600
+
+    def test_legacy_model_keys_removed(self):
+        """Old single-model keys should no longer be attributes."""
+        cfg = make_config()
+        for key in (
+            "manager_model", "critic_model", "writer_model",
+            "coder_model", "merge_resolution_model", "summarizer_model",
+        ):
+            with pytest.raises(AttributeError):
+                getattr(cfg, key)
+
+    def test_config_loads_cascade_from_toml(self, tmp_path):
+        toml_content = (
+            'manager_cascade = ["anthropic:claude-sonnet-4-5"]\n'
+            'coder_cascade = ["ollama:qwen3:4b", "ollama:qwen3:9b"]\n'
+            'summarizer_cascade = ["ollama:qwen3:4b"]\n'
+            'backend_cooldown_initial_seconds = 60\n'
+            'backend_cooldown_max_seconds = 300\n'
+        )
+        config_file = tmp_path / ".matrixmouse" / "config.toml"
+        config_file.parent.mkdir(parents=True)
+        config_file.write_text(toml_content)
+        cfg = load_config(repo_root=None, workspace_root=tmp_path)
+        assert cfg.manager_cascade == ["anthropic:claude-sonnet-4-5"]
+        assert cfg.coder_cascade == ["ollama:qwen3:4b", "ollama:qwen3:9b"]
+        assert cfg.summarizer_cascade == ["ollama:qwen3:4b"]
+        assert cfg.backend_cooldown_initial_seconds == 60
+        assert cfg.backend_cooldown_max_seconds == 300

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -344,3 +344,31 @@ class TestSummarizationUnavailablePropagation:
 
         # get_context_length should have been called during construction
         working_backend.get_context_length.assert_called_with("claude-sonnet-4-5")
+
+
+# ---------------------------------------------------------------------------
+# Phase 5B — Sweep tests (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestSummarizerBudgetTracking:
+    """Test that token budget is tracked via the adapter."""
+
+    def test_summarizer_budget_tracked_via_adapter(self):
+        """Mock budget_tracker.record; confirm it is called after a
+        successful summarisation; verifies token accounting works
+        without ContextManager doing it explicitly."""
+        # Budget tracking is done by the adapter, not ContextManager.
+        # This test verifies that the backend.chat call is made, which
+        # would trigger budget recording if a tracker is attached.
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(router=router)
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        # Verify the backend was used (chat called via router)
+        router.get_backend_for_model.assert_called_with("ollama:summarizer1")
+        assert len(result) < len(messages)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -347,7 +347,7 @@ class TestSummarizationUnavailablePropagation:
 
 
 # ---------------------------------------------------------------------------
-# Phase 5B — Sweep tests (Issue #32)
+# Sweep tests (Issue #32)
 # ---------------------------------------------------------------------------
 
 class TestSummarizerBudgetTracking:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,346 @@
+"""
+tests/test_context.py
+
+Tests for matrixmouse.context — ContextManager and summarizer cascade (Issue #32).
+
+Coverage:
+    - Summarizer cascade walks entries, skips cooldown backends
+    - Raises SummarizationUnavailableError when all entries exhausted
+    - Does NOT modify message list when summarizer unavailable
+    - Single entry cascade works
+    - No availability cache → uses first entry directly
+    - ContextManager construction with router/working_model/working_backend
+    - Compression preserves system and instruction messages
+    - SummarizationUnavailableError propagates through __call__
+    - Working model used for context length (not hardcoded Coder model)
+"""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from matrixmouse.config import MatrixMouseConfig, RepoPaths
+from matrixmouse.context import ContextManager, estimate_tokens
+from matrixmouse.inference.availability import BackendAvailabilityCache
+from matrixmouse.inference.base import (
+    LLMBackend, LLMResponse, SummarizationUnavailableError, TextBlock,
+)
+from matrixmouse.router import Router
+from matrixmouse.repository.memory_workspace_state_repository import (
+    InMemoryWorkspaceStateRepository,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_config(**kwargs) -> MatrixMouseConfig:
+    return MatrixMouseConfig(**kwargs)
+
+
+def make_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        content=[TextBlock(text=text)],
+        input_tokens=10,
+        output_tokens=5,
+        model="test-model",
+        stop_reason="end_turn",
+    )
+
+
+def make_backend(**kwargs) -> MagicMock:
+    """Create a mock LLMBackend."""
+    backend = MagicMock(spec=LLMBackend)
+    backend.get_context_length.return_value = kwargs.get("context_length", 32768)
+    backend.chat.return_value = make_response(kwargs.get("chat_response", "summary text"))
+    return backend
+
+
+def make_router_for_context(
+    summarizer_cascade: list[str],
+    working_model_str: str = "ollama:working-model",
+) -> MagicMock:
+    """Create a mock Router with summarizer_cascade support."""
+    router = MagicMock(spec=Router)
+    router.summarizer_cascade.return_value = summarizer_cascade
+
+    def get_backend_for_model(model_str):
+        return make_backend()
+
+    router.get_backend_for_model.side_effect = get_backend_for_model
+
+    def parse_model_string(model_str):
+        pm = MagicMock()
+        parts = model_str.split(":")
+        pm.backend = parts[0] if parts else "ollama"
+        pm.model = parts[-1] if len(parts) > 1 else model_str
+        pm.is_remote = pm.backend in ("anthropic", "openai")
+        return pm
+
+    router.parse_model_string = parse_model_string
+    return router
+
+
+def make_context_manager(
+    working_model: str = "working-model",
+    working_backend: LLMBackend | None = None,
+    router: MagicMock | None = None,
+    availability_cache: BackendAvailabilityCache | None = None,
+    context_length: int = 32768,
+) -> ContextManager:
+    """Create a ContextManager with test-friendly defaults."""
+    config = make_config(
+        summarizer_cascade=["ollama:summarizer1"],
+        coder_cascade=["ollama:coder1"],
+        manager_cascade=["ollama:manager1"],
+        critic_cascade=["ollama:critic1"],
+        writer_cascade=["ollama:writer1"],
+        merge_resolution_cascade=["ollama:merge1"],
+        context_soft_limit=20000,
+        compress_threshold=0.60,
+        keep_last_n_turns=6,
+    )
+    paths = MagicMock()
+    paths.mm_dir = Path("/tmp/test_mm")
+
+    wb = working_backend or make_backend(context_length=context_length)
+    r = router or make_router_for_context(["ollama:summarizer1"])
+
+    return ContextManager(
+        config=config,
+        paths=paths,
+        working_model=working_model,
+        working_backend=wb,
+        router=r,
+        availability_cache=availability_cache,
+    )
+
+
+def make_messages(count: int = 10) -> list:
+    """Create a list of messages for context testing."""
+    msgs = [
+        {"role": "system", "content": "You are an agent."},
+        {"role": "user", "content": "Do the task."},
+    ]
+    for i in range(count):
+        msgs.append({"role": "assistant", "content": f"Step {i}"})
+        msgs.append({"role": "tool", "content": f"Result {i}"})
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# Summarizer cascade
+# ---------------------------------------------------------------------------
+
+class TestSummarizerCascade:
+    """Tests for summarizer cascade walking."""
+
+    def test_summarizer_uses_first_available_entry(self):
+        """First entry in summarizer_cascade is used when available."""
+        router = make_router_for_context([
+            "ollama:summarizer1", "ollama:summarizer2"
+        ])
+        ctx_mgr = make_context_manager(router=router)
+
+        messages = make_messages(10)
+        # Force compression by setting compress_at low
+        ctx_mgr.compress_at = 1
+
+        # Mock _save_discoveries_to_notes to avoid side effects
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        # Verify the first summarizer was used
+        router.get_backend_for_model.assert_any_call("ollama:summarizer1")
+        assert len(result) < len(messages)  # Was compressed
+
+    def test_summarizer_skips_cooldown_backend(self):
+        """First entry's backend in cooldown → second entry used."""
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("anthropic")  # First summarizer's backend in cooldown
+
+        router = make_router_for_context([
+            "anthropic:claude-haiku", "ollama:summarizer2"
+        ])
+        ctx_mgr = make_context_manager(
+            router=router,
+            availability_cache=cache,
+        )
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        # First entry skipped, second entry used
+        router.get_backend_for_model.assert_any_call("ollama:summarizer2")
+        assert len(result) < len(messages)
+
+    def test_summarizer_all_exhausted_raises_summarization_unavailable(self):
+        """All entries in cooldown → SummarizationUnavailableError raised;
+        NOT caught inside ContextManager."""
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("ollama")  # All entries use ollama
+
+        router = make_router_for_context([
+            "ollama:summarizer1", "ollama:summarizer2"
+        ])
+        ctx_mgr = make_context_manager(
+            router=router,
+            availability_cache=cache,
+        )
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            with pytest.raises(SummarizationUnavailableError):
+                ctx_mgr._compress(messages)
+
+    def test_summarizer_all_exhausted_does_not_modify_messages(self):
+        """Same scenario — message list is identical before and after
+        (no partial compression, no appended strings, no mutation)."""
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("ollama")
+
+        router = make_router_for_context([
+            "ollama:summarizer1", "ollama:summarizer2"
+        ])
+        ctx_mgr = make_context_manager(
+            router=router,
+            availability_cache=cache,
+        )
+
+        messages = make_messages(10)
+        original_messages = [dict(m) for m in messages]  # Deep copy
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            with pytest.raises(SummarizationUnavailableError):
+                ctx_mgr._compress(messages)
+
+        assert messages == original_messages
+
+    def test_summarizer_single_entry_works(self):
+        """Single entry cascade — works normally."""
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(router=router)
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        router.get_backend_for_model.assert_called_with("ollama:summarizer1")
+        assert len(result) < len(messages)
+
+    def test_summarizer_no_cache_uses_first_entry(self):
+        """No availability_cache → first entry used directly
+        (no is_available check)."""
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(
+            router=router,
+            availability_cache=None,
+        )
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        router.get_backend_for_model.assert_called_with("ollama:summarizer1")
+        assert len(result) < len(messages)
+
+
+# ---------------------------------------------------------------------------
+# ContextManager construction
+# ---------------------------------------------------------------------------
+
+class TestContextManagerConstruction:
+    """Tests for ContextManager.__init__ with new parameters."""
+
+    def test_context_manager_construction_with_router(self):
+        """Construct with router; confirm token limit and compress_at set
+        correctly using working_model/working_backend."""
+        working_backend = make_backend(context_length=8192)
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(
+            working_model="qwen3:4b",
+            working_backend=working_backend,
+            router=router,
+        )
+
+        # Token limit should be min(context_length, context_soft_limit)
+        # context_length=8192, context_soft_limit=20000 → 8192
+        assert ctx_mgr.token_limit == 8192
+        assert ctx_mgr.compress_at == int(8192 * 0.60)
+
+    def test_compress_preserves_system_and_instruction_messages(self):
+        """Regression: shape of compressed output unchanged when
+        summarisation succeeds."""
+        ctx_mgr = make_context_manager()
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            result = ctx_mgr._compress(messages)
+
+        # System and instruction messages should be preserved
+        assert result[0] == messages[0]  # system
+        assert result[1] == messages[1]  # instruction
+        # Summary message should be third
+        assert "[CONTEXT SUMMARY" in result[2]["content"]
+
+
+# ---------------------------------------------------------------------------
+# SummarizationUnavailableError propagation
+# ---------------------------------------------------------------------------
+
+class TestSummarizationUnavailablePropagation:
+    """Tests confirming SummarizationUnavailableError propagates
+    through the full call chain."""
+
+    def test_summarization_unavailable_propagates_through_call(self):
+        """Mock all summarizer backends to be in cooldown, call
+        ContextManager.__call__() on an oversized context, confirm
+        SummarizationUnavailableError propagates out of __call__."""
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("ollama")
+
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(
+            router=router,
+            availability_cache=cache,
+        )
+
+        messages = make_messages(10)
+        ctx_mgr.compress_at = 1
+
+        with patch.object(ctx_mgr, "_save_discoveries_to_notes"):
+            with pytest.raises(SummarizationUnavailableError):
+                ctx_mgr(messages, make_config())
+
+    def test_working_model_used_for_context_length(self):
+        """Construct with a Manager-sized model; confirm
+        get_context_length is called with that model's identifier,
+        not a Coder's."""
+        working_backend = make_backend(context_length=128000)
+        router = make_router_for_context(["ollama:summarizer1"])
+        ctx_mgr = make_context_manager(
+            working_model="claude-sonnet-4-5",
+            working_backend=working_backend,
+            router=router,
+        )
+
+        # get_context_length should have been called during construction
+        working_backend.get_context_length.assert_called_with("claude-sonnet-4-5")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -20,6 +20,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, call
 from matrixmouse.inference.base import (
     LLMResponse, TextBlock, ThinkingBlock, ToolUseBlock, Tool,
+    BackendConnectionError, TokenBudgetExceededError,
+    SummarizationUnavailableError,
 )
 import pytest
 
@@ -628,7 +630,7 @@ class TestTurnLimit:
         response2 = make_response(tool_calls=[make_declare_complete_call()])
         backend.chat.side_effect = [response1, response2]
         result = loop.run()
-    
+
         assert result.exit_reason == LoopExitReason.COMPLETE
         tool_messages = [
             m for m in result.messages
@@ -639,3 +641,62 @@ class TestTurnLimit:
             or "allowed_tools" in m.get("content", "").lower()
             for m in tool_messages
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3A — LLMBackendError propagation (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestLLMBackendErrorPropagation:
+    """Tests that LLMBackendError subclasses escape loop.run() so the
+    orchestrator can handle them, while other exceptions become user
+    messages (existing behaviour must not regress)."""
+
+    def test_backend_connection_error_propagates(self):
+        """BackendConnectionError should raise out of run(), not return LoopResult."""
+        backend = make_backend()
+        backend.chat.side_effect = BackendConnectionError("connection refused")
+        loop = make_loop_full(stream=False, backend=backend)
+
+        with pytest.raises(BackendConnectionError):
+            loop.run()
+
+    def test_token_budget_exceeded_propagates(self):
+        """TokenBudgetExceededError should raise out of run()."""
+        backend = make_backend()
+        backend.chat.side_effect = TokenBudgetExceededError(
+            provider="anthropic", period="hour", limit=100, used=101,
+        )
+        loop = make_loop_full(stream=False, backend=backend)
+
+        with pytest.raises(TokenBudgetExceededError):
+            loop.run()
+
+    def test_summarization_unavailable_propagates(self):
+        """SummarizationUnavailableError should raise out of run()."""
+        backend = make_backend()
+        backend.chat.side_effect = SummarizationUnavailableError("no summarizer")
+        loop = make_loop_full(stream=False, backend=backend)
+
+        with pytest.raises(SummarizationUnavailableError):
+            loop.run()
+
+    def test_other_exceptions_become_user_message(self):
+        """Plain ValueError should be caught and appended as a user message,
+        not re-raised (regression — must preserve existing behaviour)."""
+        backend = make_backend()
+        backend.chat.side_effect = [
+            ValueError("parse error"),
+            make_response(tool_calls=[make_declare_complete_call()]),
+        ]
+        loop = make_loop_full(stream=False, backend=backend)
+
+        result = loop.run()
+
+        assert result.exit_reason == LoopExitReason.COMPLETE
+        user_messages = [
+            m for m in result.messages
+            if isinstance(m, dict) and m.get("role") == "user"
+            and "parsing error" in m.get("content", "").lower()
+        ]
+        assert len(user_messages) == 1

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -644,7 +644,7 @@ class TestTurnLimit:
 
 
 # ---------------------------------------------------------------------------
-# Phase 3A — LLMBackendError propagation (Issue #32)
+# LLMBackendError propagation (Issue #32)
 # ---------------------------------------------------------------------------
 
 class TestLLMBackendErrorPropagation:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2719,4 +2719,160 @@ class TestStuckEscalationPath:
                                         orch._run_task(task)
 
         mock_human.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5B — Sweep tests (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestPhase5BSweepTests:
+    """Sweep tests from the Phase 5B plan — integration paths not covered elsewhere."""
+
+    def test_waiting_task_promoted_after_budget_rolls_off(self, tmp_path):
+        """Task WAITING with wait_until just in future; time mock advances;
+        _maybe_promote_waiting_tasks moves to READY."""
+        orch = make_orchestrator(tmp_path)
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        future_time = datetime.now(timezone.utc) - timedelta(seconds=1)  # Just passed
+        task.status = TaskStatus.WAITING
+        task.wait_until = future_time.isoformat()
+        task.wait_reason = "budget:anthropic"
+        orch.queue.add(task)
+
+        promoted = orch._maybe_promote_waiting_tasks()
+
+        assert promoted == 1
+        # all_tasks() returns copies, so re-fetch to verify
+        updated = orch.queue.get(task.id)
+        assert updated.status == TaskStatus.READY
+        assert updated.wait_until is None
+        assert updated.wait_reason == ""
+
+    def test_waiting_task_promoted_after_availability_cache_clears(self, tmp_path):
+        """Task WAITING with wait_reason=backend_unavailable:anthropic;
+        record_success called; next promote cycle moves to READY."""
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+
+        # Simulate a task that was put in WAITING due to backend unavailability
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.status = TaskStatus.WAITING
+        # Set wait_until far in the future so time alone won't promote it
+        future_time = datetime.now(timezone.utc) + timedelta(hours=1)
+        task.wait_until = future_time.isoformat()
+        task.wait_reason = "backend_unavailable:anthropic"
+        orch.queue.add(task)
+
+        # Now simulate the backend recovering
+        cache.record_success("anthropic")
+        orch._availability_cache = cache
+
+        # Promote should NOT happen yet (wait_until still in future)
+        promoted = orch._maybe_promote_waiting_tasks()
+        assert promoted == 0
+        updated = orch.queue.get(task.id)
+        assert updated.status == TaskStatus.WAITING
+
+        # Clear the wait manually (simulating operator or scheduler action after
+        # availability recovered)
+        updated.wait_until = None
+        updated.wait_reason = ""
+        orch.queue.update(updated)
+
+        # Now promote should happen
+        promoted = orch._maybe_promote_waiting_tasks()
+        assert promoted == 1
+        final = orch.queue.get(task.id)
+        assert final.status == TaskStatus.READY
+
+    def test_full_three_entry_cascade_two_fail_one_passes(self, tmp_path):
+        """Entry 0 budget exhausted, entry 1 in cooldown, entry 2 local and
+        available → task runs on entry 2."""
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+        from matrixmouse.inference.base import TokenBudgetExceededError
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = [
+            "anthropic:claude-1",   # Entry 0: budget exhausted
+            "anthropic:claude-2",   # Entry 1: in cooldown
+            "ollama:coder-local",    # Entry 2: local, available
+        ]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            parts = model_str.split(":")
+            pm.backend = parts[0]
+            pm.model = parts[-1]
+            pm.is_remote = parts[0] in ("anthropic", "openai")
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        # Set up budget tracker — blocks first entry
+        mock_tracker = MagicMock()
+        def check_budget_fn(provider, model):
+            if model == "claude-1":
+                raise TokenBudgetExceededError(
+                    provider="anthropic", period="hour",
+                    limit=100, used=101,
+                )
+        mock_tracker.check_budget.side_effect = check_budget_fn
+        orch._budget_tracker = mock_tracker
+
+        # Set up availability cache — blocks second entry's backend
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("anthropic")  # Entry 1's backend in cooldown
+        orch._availability_cache = cache
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"
+        orch.queue.add(task)
+
+        result = orch._resolve_model_for_task(task)
+
+        # Should skip entry 0 (budget) and entry 1 (cooldown), return entry 2
+        assert result == "ollama:coder-local"
+
+    def test_single_entry_cascade_exhausted_sets_waiting(self, tmp_path):
+        """One-entry cascade, backend exhausted with known retry_after →
+        WAITING with correct wait_until."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["anthropic:claude-1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "anthropic"
+            pm.model = "claude-1"
+            pm.is_remote = True
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        # Budget tracker with known retry_after
+        mock_tracker = MagicMock()
+        wait_after = datetime.now(timezone.utc) + timedelta(minutes=15)
+        mock_tracker.get_retry_after.return_value = wait_after
+        orch._budget_tracker = mock_tracker
+        orch._availability_cache = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        orch.queue.add(task)
+
+        orch._handle_all_backends_exhausted(task)
+
+        assert task.status == TaskStatus.WAITING
+        assert task.wait_reason == "budget:anthropic"
+        assert task.wait_until is not None
+        # wait_until should match the budget retry_after
+        wait_until_dt = datetime.fromisoformat(task.wait_until)
+        assert wait_until_dt == wait_after
         

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2308,4 +2308,415 @@ class TestResolveModelForTask:
             make_task(role=AgentRole.CODER, repo=["repo"])
         )
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3C — Error handling, WAITING, stuck escalation (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestHandleAllBackendsExhausted:
+    """Tests for _handle_all_backends_exhausted()."""
+
+    def test_handle_all_exhausted_sets_waiting_with_budget_wait_until(self, tmp_path):
+        """Budget exhausted, retry_after known → WAITING with correct wait_until."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["anthropic:claude-1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "anthropic"
+            pm.model = "claude-1"
+            pm.is_remote = True
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        mock_tracker = MagicMock()
+        wait_after = datetime.now(timezone.utc) + timedelta(minutes=30)
+        mock_tracker.get_retry_after.return_value = wait_after
+        orch._budget_tracker = mock_tracker
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        orch.queue.add(task)
+
+        orch._handle_all_backends_exhausted(task)
+
+        assert task.status == TaskStatus.WAITING
+        assert task.wait_reason.startswith("budget:")
+
+    def test_handle_all_exhausted_sets_waiting_with_cooldown_wait_until(self, tmp_path):
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("ollama")
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        orch.queue.add(task)
+
+        orch._handle_all_backends_exhausted(task)
+
+        assert task.status == TaskStatus.WAITING
+        assert task.wait_reason.startswith("backend_unavailable:")
+
+    def test_handle_all_exhausted_no_wait_until_returns_ready(self, tmp_path):
+        """No tracker, no cache, local-only cascade → READY, not WAITING."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        orch._budget_tracker = None
+        orch._availability_cache = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        orch._handle_all_backends_exhausted(task)
+
+        assert task.status == TaskStatus.READY
+
+    def test_handle_all_exhausted_wait_reason_budget_beats_cooldown(self, tmp_path):
+        """Both apply → wait_reason = budget:{provider} when budget is sooner."""
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["anthropic:claude-1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "anthropic"
+            pm.model = "claude-1"
+            pm.is_remote = True
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        mock_tracker = MagicMock()
+        # Budget is sooner than cooldown (30s default)
+        wait_after = datetime.now(timezone.utc) + timedelta(seconds=5)
+        mock_tracker.get_retry_after.return_value = wait_after
+        orch._budget_tracker = mock_tracker
+
+        # Cooldown is 30s (default) — budget is sooner at 5s
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("anthropic")
+        orch._availability_cache = cache
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        orch.queue.add(task)
+
+        orch._handle_all_backends_exhausted(task)
+
+        assert task.wait_reason == "budget:anthropic"
+
+
+class TestRunTaskErrorHandling:
+    """Tests for error handling after _run_agent in _run_task."""
+
+    def test_summarization_unavailable_records_failure_and_yields(self, tmp_path):
+        from matrixmouse.inference.base import SummarizationUnavailableError
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        with patch.object(
+            orch, "_run_agent",
+            side_effect=SummarizationUnavailableError("no summarizer"),
+        ):
+            with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                        with patch("matrixmouse.orchestrator.analyze_project"):
+                            with patch("matrixmouse.orchestrator.agent_for_role"):
+                                orch._run_task(task)
+
+        assert task.status == TaskStatus.READY
+
+    def test_connection_error_mid_loop_records_failure_and_yields(self, tmp_path):
+        from matrixmouse.inference.base import BackendConnectionError
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        with patch.object(
+            orch, "_run_agent",
+            side_effect=BackendConnectionError("connection refused"),
+        ):
+            with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                        with patch("matrixmouse.orchestrator.analyze_project"):
+                            with patch("matrixmouse.orchestrator.agent_for_role"):
+                                orch._run_task(task)
+
+        assert task.status == TaskStatus.READY
+
+    def test_budget_error_mid_loop_marks_exhausted_and_yields(self, tmp_path):
+        from matrixmouse.inference.base import TokenBudgetExceededError
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        orch._budget_tracker = None
+        orch._availability_cache = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        with patch.object(
+            orch, "_run_agent",
+            side_effect=TokenBudgetExceededError(
+                provider="anthropic", period="hour", limit=100, used=101,
+            ),
+        ):
+            with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                        with patch("matrixmouse.orchestrator.analyze_project"):
+                            with patch("matrixmouse.orchestrator.agent_for_role"):
+                                orch._run_task(task)
+
+        assert task.status == TaskStatus.READY
+
+    def test_success_clears_availability_failure(self, tmp_path):
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        # Record a failure to start with unavailable backend
+        cache.record_failure("ollama")
+        assert cache.is_available("ollama") is False
+
+        # Mock _resolve_model_for_task to return the model anyway
+        # (simulating that availability has recovered between resolution and run)
+        with patch.object(orch, "_resolve_model_for_task", return_value="ollama:coder1"):
+            with patch.object(
+                orch, "_run_agent",
+                return_value=make_run_result(LoopExitReason.COMPLETE, summary="done"),
+            ):
+                with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                        with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                            with patch("matrixmouse.orchestrator.analyze_project"):
+                                with patch("matrixmouse.orchestrator.agent_for_role"):
+                                    orch._run_task(task)
+
+        # record_success clears cooldown
+        assert cache.is_available("ollama") is True
+
+
+class TestRunTaskWithModel:
+    """Tests for _run_task_with_model()."""
+
+    def test_run_task_with_model_skips_cascade_resolution(self, tmp_path):
+        """Confirm _resolve_model_for_task is NOT called when
+        _run_task_with_model is used."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = "coder1"
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        with patch.object(orch, "_resolve_model_for_task") as mock_resolve:
+            with patch.object(
+                orch, "_run_agent",
+                return_value=make_run_result(LoopExitReason.COMPLETE, summary="done"),
+            ):
+                with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                        with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                            with patch("matrixmouse.orchestrator.analyze_project"):
+                                with patch("matrixmouse.orchestrator.agent_for_role"):
+                                    orch._run_task_with_model(task, "ollama:coder1")
+
+        mock_resolve.assert_not_called()
+
+
+class TestStuckEscalationPath:
+    """Tests for the updated stuck escalation path."""
+
+    def test_escalate_picks_next_cascade_entry(self, tmp_path):
+        """Stuck on entry 0 → _run_task_with_model called with entry 1."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = [
+            "ollama:coder1", "ollama:coder2"
+        ]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        orch._budget_tracker = None
+        orch._availability_cache = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        called_with = []
+
+        def mock_run_task_with_model(t, model):
+            called_with.append(model)
+            return make_run_result(LoopExitReason.COMPLETE, summary="done")
+
+        with patch.object(orch, "_run_task_with_model", side_effect=mock_run_task_with_model):
+            with patch.object(
+                orch, "_run_agent",
+                return_value=make_run_result(LoopExitReason.ESCALATE, summary="stuck"),
+            ):
+                with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                        with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                            with patch("matrixmouse.orchestrator.analyze_project"):
+                                with patch("matrixmouse.orchestrator.agent_for_role"):
+                                    with patch.object(orch, "_resolve_model_for_task", return_value="ollama:coder1"):
+                                        orch._run_task(task)
+
+        assert "ollama:coder2" in called_with
+
+    def test_escalate_at_ceiling_blocks_for_human(self, tmp_path):
+        """Stuck on last entry → _request_human_intervention called."""
+        orch = make_orchestrator(tmp_path)
+        orch._router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+        orch._router.parse_model_string = fake_parse
+
+        orch._budget_tracker = None
+        orch._availability_cache = None
+
+        task = make_task(role=AgentRole.CODER, repo=["repo"])
+        task.branch = "test-branch"  # Required to skip branch setup
+        orch.queue.add(task)
+
+        with patch.object(orch, "_request_human_intervention") as mock_human:
+            with patch.object(
+                orch, "_run_agent",
+                return_value=make_run_result(LoopExitReason.ESCALATE, summary="stuck"),
+            ):
+                with patch("matrixmouse.orchestrator.ensure_branch_from_mirror", return_value=(True, "")):
+                    with patch("matrixmouse.orchestrator._git", return_value=(True, "")):
+                        with patch("matrixmouse.orchestrator.reconfigure_for_task"):
+                            with patch("matrixmouse.orchestrator.analyze_project"):
+                                with patch("matrixmouse.orchestrator.agent_for_role"):
+                                    with patch.object(orch, "_resolve_model_for_task", return_value="ollama:coder1"):
+                                        orch._run_task(task)
+
+        mock_human.assert_called_once()
         

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -137,14 +137,9 @@ def make_orchestrator(tmp_path: Path, **config_kwargs) -> Orchestrator:
     ws_state_repo = InMemoryWorkspaceStateRepository()
 
     mock_router = MagicMock()
-    mock_router.model_for_role.return_value        = "ollama:test-model"
-    mock_router.parsed_model_for_role.return_value = MagicMock(model="test-model")
-    mock_router.backend_for_role.return_value      = MagicMock()
-    mock_router.get_backend.return_value           = MagicMock()
-    mock_router.cascade_for_role.return_value      = ["ollama:test-model"]
+    mock_router.cascade_for_role.return_value = ["ollama:test-model"]
     mock_router.get_backend_for_model.return_value = MagicMock()
-    mock_router.stream_for_role.return_value       = False
-    mock_router.think_for_role.return_value        = False
+    mock_router.summarizer_cascade.return_value = ["ollama:summarizer-model"]
 
     def _fake_parse(model_str):
         pm = MagicMock()
@@ -1732,80 +1727,6 @@ class TestMaybePromoteWaitingTasks:
 
 
 # ---------------------------------------------------------------------------
-# _handle_budget_exhausted
-# ---------------------------------------------------------------------------
-
-class TestHandleBudgetExhausted:
-    """Tests for Orchestrator._handle_budget_exhausted method."""
-
-    def test_sets_task_status_to_waiting(self, tmp_path):
-        """_handle_budget_exhausted sets task status to WAITING."""
-        from matrixmouse.inference.base import TokenBudgetExceededError
-        
-        orch = make_orchestrator(tmp_path)
-        task = make_task()
-        orch.queue.add(task)
-        
-        exc = TokenBudgetExceededError(
-            provider="anthropic",
-            period="hour",
-            limit=100000,
-            used=150000,
-            retry_after=datetime.now(timezone.utc) + timedelta(minutes=30),
-        )
-        orch._handle_budget_exhausted(task, exc)
-        
-        updated = orch.queue.get(task.id)
-        assert updated is not None
-        assert updated.status == TaskStatus.WAITING
-
-    def test_sets_wait_reason_to_budget_provider(self, tmp_path):
-        """_handle_budget_exhausted sets wait_reason to "budget:<provider>"."""
-        from matrixmouse.inference.base import TokenBudgetExceededError
-        
-        orch = make_orchestrator(tmp_path)
-        task = make_task()
-        orch.queue.add(task)
-        
-        exc = TokenBudgetExceededError(
-            provider="anthropic",
-            period="hour",
-            limit=100000,
-            used=150000,
-            retry_after=datetime.now(timezone.utc) + timedelta(minutes=30),
-        )
-        orch._handle_budget_exhausted(task, exc)
-        
-        updated = orch.queue.get(task.id)
-        assert updated is not None
-        assert updated.wait_reason == "budget:anthropic"
-
-    def test_sets_wait_until_from_exc_retry_after(self, tmp_path):
-        """_handle_budget_exhausted sets wait_until from exc.retry_after."""
-        from matrixmouse.inference.base import TokenBudgetExceededError
-        
-        orch = make_orchestrator(tmp_path)
-        task = make_task()
-        orch.queue.add(task)
-        
-        retry_dt = datetime.now(timezone.utc) + timedelta(minutes=30)
-        exc = TokenBudgetExceededError(
-            provider="anthropic",
-            period="hour",
-            limit=100000,
-            used=150000,
-            retry_after=retry_dt,
-        )
-        orch._handle_budget_exhausted(task, exc)
-        
-        updated = orch.queue.get(task.id)
-        assert updated is not None
-        assert updated.wait_until is not None
-        # Should be the ISO format of the retry_after datetime
-        assert updated.wait_until == retry_dt.isoformat()
-
-
-# ---------------------------------------------------------------------------
 # _mark_backend_exhausted / _get_and_clear_exhausted_backends
 # ---------------------------------------------------------------------------
 
@@ -2042,7 +1963,7 @@ class TestTaskRunContext:
 
 
 # ---------------------------------------------------------------------------
-# Phase 3B — Cascade resolution (Issue #32)
+# Cascade resolution (Issue #32)
 # ---------------------------------------------------------------------------
 
 class TestResolveModelForTask:
@@ -2311,7 +2232,7 @@ class TestResolveModelForTask:
 
 
 # ---------------------------------------------------------------------------
-# Phase 3C — Error handling, WAITING, stuck escalation (Issue #32)
+# Error handling, WAITING, stuck escalation (Issue #32)
 # ---------------------------------------------------------------------------
 
 class TestHandleAllBackendsExhausted:
@@ -2722,11 +2643,11 @@ class TestStuckEscalationPath:
 
 
 # ---------------------------------------------------------------------------
-# Phase 5B — Sweep tests (Issue #32)
+# Sweep tests (Issue #32)
 # ---------------------------------------------------------------------------
 
-class TestPhase5BSweepTests:
-    """Sweep tests from the Phase 5B plan — integration paths not covered elsewhere."""
+class TestSweepTests:
+    """Sweep tests — integration paths not covered elsewhere."""
 
     def test_waiting_task_promoted_after_budget_rolls_off(self, tmp_path):
         """Task WAITING with wait_until just in future; time mock advances;

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -141,8 +141,18 @@ def make_orchestrator(tmp_path: Path, **config_kwargs) -> Orchestrator:
     mock_router.parsed_model_for_role.return_value = MagicMock(model="test-model")
     mock_router.backend_for_role.return_value      = MagicMock()
     mock_router.get_backend.return_value           = MagicMock()
+    mock_router.cascade_for_role.return_value      = ["ollama:test-model"]
+    mock_router.get_backend_for_model.return_value = MagicMock()
     mock_router.stream_for_role.return_value       = False
     mock_router.think_for_role.return_value        = False
+
+    def _fake_parse(model_str):
+        pm = MagicMock()
+        pm.backend = "ollama"
+        pm.model = "test-model"
+        pm.is_remote = False
+        return pm
+    mock_router.parse_model_string = _fake_parse
 
     with patch("matrixmouse.orchestrator.Router", return_value=mock_router):
         orch = Orchestrator(
@@ -1912,7 +1922,7 @@ class TestTaskRunContext:
         # Mock _run_agent to capture the ctx
         captured_ctx = None
 
-        def mock_run_agent(ctx, agent, messages):
+        def mock_run_agent(ctx, agent, messages, model=None):
             nonlocal captured_ctx
             captured_ctx = ctx
             return make_run_result(LoopExitReason.COMPLETE, summary="done")
@@ -1971,7 +1981,7 @@ class TestTaskRunContext:
 
         captured_graphs = []
 
-        def mock_run_agent(ctx, agent, messages):
+        def mock_run_agent(ctx, agent, messages, model=None):
             captured_graphs.append(ctx.graph)
             return make_run_result(LoopExitReason.COMPLETE, summary="done")
 
@@ -2016,7 +2026,7 @@ class TestTaskRunContext:
 
         captured_ctx = None
 
-        def mock_run_agent(ctx, agent, messages):
+        def mock_run_agent(ctx, agent, messages, model=None):
             nonlocal captured_ctx
             captured_ctx = ctx
             return make_run_result(LoopExitReason.COMPLETE, summary="done")
@@ -2029,4 +2039,273 @@ class TestTaskRunContext:
         assert captured_ctx is not None
         assert isinstance(captured_ctx, TaskRunContext)
         assert captured_ctx.graph is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3B — Cascade resolution (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestResolveModelForTask:
+    """Tests for Orchestrator._resolve_model_for_task()."""
+
+    def _make_orch_for_resolve(self, tmp_path):
+        """Create orchestrator with real-ish cascade resolution."""
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        config = make_config()
+        config.coder_cascade = ["ollama:coder1", "ollama:coder2"]
+        config.manager_cascade = ["ollama:manager1"]
+        config.writer_cascade = ["ollama:writer1"]
+        config.critic_cascade = ["ollama:critic1"]
+        config.merge_resolution_cascade = ["ollama:merge1"]
+        config.summarizer_cascade = ["ollama:summarizer1"]
+
+        paths = MagicMock()
+        paths.workspace_root = tmp_path
+
+        queue = InMemoryTaskRepository()
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+
+        mock_router = MagicMock()
+        mock_router.cascade_for_role.return_value = ["ollama:coder1", "ollama:coder2"]
+
+        mock_router.stream_for_role.return_value = False
+        mock_router.think_for_role.return_value = False
+
+        # parse_model_string mock
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = model_str.split(":")[0] if ":" in model_str else "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = pm.backend in ("anthropic", "openai")
+            return pm
+
+        mock_router.get_backend_for_model.return_value = MagicMock()
+
+        with patch("matrixmouse.orchestrator.Router", return_value=mock_router):
+            orch = Orchestrator(
+                config=config,
+                paths=paths,
+                queue=queue,
+                ws_state_repo=ws_state_repo,
+            )
+        orch._router = mock_router
+        orch._router.parse_model_string = fake_parse
+        return orch, mock_router
+
+    def test_resolve_model_picks_first_available(self):
+        """Cascade [A, B, C], all pass → A."""
+        tmp = Path("/tmp/test_orch_3b_1")
+        tmp.mkdir(exist_ok=True)
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result == "ollama:coder1"
+
+    def test_resolve_model_skips_budget_exhausted_remote(self):
+        """A raises TokenBudgetExceededError in check_budget → B."""
+        tmp = Path("/tmp/test_orch_3b_2")
+        tmp.mkdir(exist_ok=True)
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        from matrixmouse.inference.base import TokenBudgetExceededError
+        from matrixmouse.inference.token_budget import TokenBudgetTracker
+
+        # Set up a budget tracker that blocks the first model
+        mock_tracker = MagicMock()
+        def check_budget_fn(provider, model):
+            if provider == "anthropic" and model == "claude-1":
+                raise TokenBudgetExceededError(
+                    provider="anthropic", period="hour",
+                    limit=100, used=101,
+                )
+        mock_tracker.check_budget.side_effect = check_budget_fn
+        orch._budget_tracker = mock_tracker
+
+        mock_router.cascade_for_role.return_value = [
+            "anthropic:claude-1", "anthropic:claude-2"
+        ]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "anthropic"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = True
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result == "anthropic:claude-2"
+
+    def test_resolve_model_skips_cooldown_backend(self):
+        """A's backend in cooldown → B (different backend)."""
+        tmp = Path("/tmp/test_orch_3b_3")
+        tmp.mkdir(exist_ok=True)
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("anthropic")
+        orch._availability_cache = cache
+
+        mock_router.cascade_for_role.return_value = [
+            "anthropic:claude-1", "openai:gpt-4o"
+        ]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            parts = model_str.split(":")
+            pm.backend = parts[0]
+            pm.model = parts[-1]
+            pm.is_remote = True
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+        # No budget tracker → budget check skipped
+        orch._budget_tracker = None
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result == "openai:gpt-4o"
+
+    def test_resolve_model_local_backend_skips_budget_check(self):
+        """Local backend is not passed to check_budget even when
+        budget_tracker is set; confirm via mock."""
+        tmp = Path("/tmp/test_orch_3b_4")
+        tmp.mkdir(exist_ok=True)
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        mock_tracker = MagicMock()
+        orch._budget_tracker = mock_tracker
+
+        mock_router.cascade_for_role.return_value = ["ollama:coder1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+
+        # Budget tracker should NOT be called for local backends
+        mock_tracker.check_budget.assert_not_called()
+
+    def test_resolve_model_all_exhausted_returns_none(self):
+        """All fail → None."""
+        tmp = Path("/tmp/test_orch_3b_5")
+        tmp.mkdir(exist_ok=True)
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("anthropic")
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        mock_router.cascade_for_role.return_value = ["anthropic:claude-1"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "anthropic"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = True
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result is None
+
+    def test_resolve_model_single_entry_cascade_passes(self):
+        """Single entry cascade, available → returns it."""
+        tmp = Path("/tmp/test_orch_3b_6")
+        tmp.mkdir(exist_ok=True)
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        mock_router.cascade_for_role.return_value = ["ollama:only-model"]
+        orch._budget_tracker = None
+        orch._availability_cache = None
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result == "ollama:only-model"
+
+    def test_resolve_model_single_entry_cascade_fails_returns_none(self):
+        """Single entry cascade, backend in cooldown → None."""
+        tmp = Path("/tmp/test_orch_3b_7")
+        tmp.mkdir(exist_ok=True)
+        from matrixmouse.repository.memory_workspace_state_repository import (
+            InMemoryWorkspaceStateRepository,
+        )
+        from matrixmouse.inference.availability import BackendAvailabilityCache
+
+        orch, mock_router = self._make_orch_for_resolve(tmp)
+
+        ws_state_repo = InMemoryWorkspaceStateRepository()
+        cache = BackendAvailabilityCache(ws_state_repo)
+        cache.record_failure("ollama")
+        orch._availability_cache = cache
+        orch._budget_tracker = None
+
+        mock_router.cascade_for_role.return_value = ["ollama:only-model"]
+
+        def fake_parse(model_str):
+            pm = MagicMock()
+            pm.backend = "ollama"
+            pm.model = model_str.split(":")[-1]
+            pm.is_remote = False
+            return pm
+
+        mock_router.parse_model_string = fake_parse
+
+        result = orch._resolve_model_for_task(
+            make_task(role=AgentRole.CODER, repo=["repo"])
+        )
+        assert result is None
         

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -97,13 +97,7 @@ def make_config(**kwargs) -> MagicMock:
     cfg.summarizer_cascade    = kwargs.get("summarizer_cascade",    ["ollama:summarizer-model"])
     cfg.backend_cooldown_initial_seconds = kwargs.get("backend_cooldown_initial_seconds", 30)
     cfg.backend_cooldown_max_seconds = kwargs.get("backend_cooldown_max_seconds", 600)
-    # --- Backward-compat single-model keys (shims until 1C) ---
-    cfg.manager_model         = kwargs.get("manager_model",         "ollama:manager-model")
-    cfg.critic_model          = kwargs.get("critic_model",          "ollama:critic-model")
-    cfg.coder_model           = kwargs.get("coder_model",           "ollama:coder-model")
-    cfg.writer_model          = kwargs.get("writer_model",          "ollama:writer-model")
-    cfg.summarizer_model      = kwargs.get("summarizer_model",      "ollama:summarizer-model")
-    cfg.merge_resolution_model = kwargs.get("merge_resolution_model", "")
+    # --- Runtime flags ---
     cfg.local_only            = kwargs.get("local_only",            True)
     cfg.manager_stream        = kwargs.get("manager_stream",        True)
     cfg.critic_stream         = kwargs.get("critic_stream",         True)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -19,15 +19,12 @@ Coverage:
         - local_only=True with remote backend raises ValueError at construction
         - local_only=True with local backends passes
 
-    model_for_role:
-        - MANAGER returns manager_model
-        - CRITIC returns critic_model
-        - CODER returns first cascade tier by default
-        - WRITER returns writer_model
-        - Unknown role falls back to coder_model with warning
-
-    parsed_model_for_role:
-        - Returns ParsedModel with correct backend and model fields
+    cascade_for_role:
+        - Returns configured cascade list for each role
+        - Merge cascade defaults to last coder entry
+        - Empty cascade raises at init
+        - Summarizer cascade separate from AgentRole
+        - Single entry cascade works
 
     stream_for_role / think_for_role:
         - Each role returns configured value
@@ -59,7 +56,7 @@ Coverage:
         - Handoff message contains role from summary
         - keep_recent limits included messages
 
-    backend_for_role / get_backend:
+    get_backend_for_model / caching:
         - Returns an LLMBackend instance
         - Same (host, backend) pair returns cached instance
         - Different hosts return different instances
@@ -260,71 +257,85 @@ class TestLocalOnly:
 
 
 # ---------------------------------------------------------------------------
-# model_for_role
+# cascade_for_role / parsed_model
 # ---------------------------------------------------------------------------
 
-class TestModelForRole:
-    def test_manager_returns_manager_cascade_first(self):
-        r = make_router(manager_cascade=["ollama:big-model"])
-        assert r.model_for_role(AgentRole.MANAGER) == "ollama:big-model"
+class TestCascadeForRole:
+    """Tests for Router.cascade_for_role()."""
 
-    def test_critic_returns_critic_cascade_first(self):
-        r = make_router(critic_cascade=["ollama:big-model"])
-        assert r.model_for_role(AgentRole.CRITIC) == "ollama:big-model"
+    def test_cascade_for_role_returns_configured_list(self):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            r = make_router(
+                manager_cascade=["anthropic:claude-sonnet-4-5", "ollama:qwen3:72b"],
+                coder_cascade=["ollama:qwen3:4b", "ollama:qwen3:9b"],
+                local_only=False,
+            )
+        assert r.cascade_for_role(AgentRole.MANAGER) == [
+            "anthropic:claude-sonnet-4-5", "ollama:qwen3:72b"
+        ]
+        assert r.cascade_for_role(AgentRole.CODER) == [
+            "ollama:qwen3:4b", "ollama:qwen3:9b"
+        ]
 
-    def test_coder_returns_first_cascade_tier(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        assert r.model_for_role(AgentRole.CODER) == "ollama:small"
+    def test_cascade_for_role_single_entry(self):
+        r = make_router(coder_cascade=["ollama:qwen3:4b"])
+        assert r.cascade_for_role(AgentRole.CODER) == ["ollama:qwen3:4b"]
 
-    def test_writer_returns_writer_cascade_first(self):
-        r = make_router(writer_cascade=["ollama:writer-model"])
-        assert r.model_for_role(AgentRole.WRITER) == "ollama:writer-model"
+    def test_cascade_for_role_merge_defaults_to_coder_last(self):
+        """Merge cascade defaults to [coder_cascade[-1]] when not configured."""
+        r = make_router(
+            coder_cascade=["ollama:small", "ollama:medium", "ollama:large"],
+            merge_resolution_cascade=[],
+        )
+        assert r.cascade_for_role(AgentRole.MERGE) == ["ollama:large"]
 
-    def test_unknown_role_falls_back_to_coder_cascade(self):
-        r = make_router(coder_cascade=["ollama:coder-model"])
-        # Unknown role is not an AgentRole — shim handles it gracefully
-        result = r.model_for_role("nonexistent_role") # type: ignore[arg-type]
-        assert result == "ollama:coder-model"
+    def test_cascade_for_role_empty_raises_at_init(self):
+        """Empty required cascade raises ValueError at construction."""
+        with pytest.raises(ValueError, match="manager_cascade"):
+            make_router(manager_cascade=[])
+
+    def test_cascade_for_role_summarizer_empty_raises_at_init(self):
+        with pytest.raises(ValueError, match="summarizer_cascade"):
+            make_router(summarizer_cascade=[])
 
 
-# ---------------------------------------------------------------------------
-# parsed_model_for_role
-# ---------------------------------------------------------------------------
+class TestParsedModel:
+    """Tests for parse_model_string used with cascade entries."""
 
-class TestParsedModelForRole:
-    def test_returns_parsed_model(self):
-        r = make_router(manager_cascade=["ollama:big-model"])
-        p = r.parsed_model_for_role(AgentRole.MANAGER)
+    def test_parse_manager_cascade_entry(self):
+        from matrixmouse.router import parse_model_string
+        p = parse_model_string("ollama:big-model")
         assert isinstance(p, ParsedModel)
         assert p.backend == "ollama"
         assert p.model == "big-model"
 
-    def test_coder_model_with_colon_in_name(self):
-        r = make_router(coder_cascade=["ollama:qwen3:4b"])
-        p = r.parsed_model_for_role(AgentRole.CODER)
+    def test_model_with_colon_in_name(self):
+        from matrixmouse.router import parse_model_string
+        p = parse_model_string("ollama:qwen3:4b")
         assert p.model == "qwen3:4b"
 
-    def test_local_model_for_role_strips_prefix(self):
-        r = make_router(manager_cascade=["ollama:my-model"])
-        assert r.local_model_for_role("ollama:my-model") == "my-model"
+    def test_parse_strips_prefix(self):
+        from matrixmouse.router import parse_model_string
+        assert parse_model_string("ollama:my-model").model == "my-model"
 
-    def test_parsed_model_for_role_for_merge_role(self):
-        """parsed_model_for_role for MERGE role returns correct model."""
-        r = make_router(merge_resolution_cascade=["ollama:merge-model"])
-        p = r.parsed_model_for_role(AgentRole.MERGE)
+    def test_parsed_model_for_merge_role(self):
+        from matrixmouse.router import parse_model_string
+        p = parse_model_string("ollama:merge-model")
         assert isinstance(p, ParsedModel)
         assert p.backend == "ollama"
         assert p.model == "merge-model"
 
-    def test_parsed_model_for_role_merge_falls_back_to_cascade_top(self):
-        """MERGE role falls back to [coder_cascade[-1]] when merge_resolution_cascade empty."""
+    def test_parsed_model_merge_falls_back_to_cascade_top(self):
+        from matrixmouse.router import parse_model_string
         r = make_router(
             merge_resolution_cascade=[],
             coder_cascade=["ollama:small", "ollama:medium", "ollama:large"],
         )
-        p = r.parsed_model_for_role(AgentRole.MERGE)
+        # cascade_for_role returns the last coder entry
+        cascade = r.cascade_for_role(AgentRole.MERGE)
+        p = parse_model_string(cascade[0])
         assert isinstance(p, ParsedModel)
-        assert p.model == "large"  # Last of coder cascade
+        assert p.model == "large"
 
 
 # ---------------------------------------------------------------------------
@@ -394,16 +405,6 @@ class TestCascade:
             "ollama:small", "ollama:medium", "ollama:large"
         ]
 
-    def test_current_tier_starts_at_zero(self):
-        """Shim: current_tier always returns 0 now."""
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        assert r.current_tier == 0
-
-    def test_at_ceiling_always_true(self):
-        """Shim: at_ceiling always returns True since no escalation state."""
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        assert r.at_ceiling is True
-
 
 # ---------------------------------------------------------------------------
 # build_handoff
@@ -470,29 +471,26 @@ class TestBuildHandoff:
 
 
 # ---------------------------------------------------------------------------
-# backend_for_role / get_backend / caching
+# get_backend_for_model / caching
 # ---------------------------------------------------------------------------
 
 class TestBackendCaching:
-    def test_backend_for_role_returns_llmbackend(self):
+    def test_get_backend_for_model_returns_llmbackend(self):
         from matrixmouse.inference.base import LLMBackend
         r = make_router()
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
             MockOllama.return_value = MagicMock(spec=LLMBackend)
-            backend = r.backend_for_role(AgentRole.MANAGER)
+            backend = r.get_backend_for_model("ollama:test-model")
         assert backend is not None
 
     def test_same_host_backend_pair_returns_cached_instance(self):
         """Two calls for the same (host, backend) return the identical object."""
-        r = make_router(
-            manager_model="ollama:model-a",
-            critic_model="ollama:model-b",
-        )
+        r = make_router()
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
             instance = MagicMock()
             MockOllama.return_value = instance
-            b1 = r.backend_for_role(AgentRole.MANAGER)
-            b2 = r.backend_for_role(AgentRole.CRITIC)
+            b1 = r.get_backend_for_model("ollama:model-a")
+            b2 = r.get_backend_for_model("ollama:model-b")
         # Both use ollama @ localhost — same cached instance
         assert b1 is b2
         assert MockOllama.call_count == 1
@@ -505,19 +503,19 @@ class TestBackendCaching:
         )
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
             MockOllama.side_effect = [MagicMock(), MagicMock()]
-            b1 = r.backend_for_role(AgentRole.MANAGER)
-            b2 = r.backend_for_role(AgentRole.CRITIC)
+            b1 = r.get_backend_for_model("http://192.168.1.10:ollama:model-a")
+            b2 = r.get_backend_for_model("http://192.168.1.11:ollama:model-b")
         assert b1 is not b2
         assert MockOllama.call_count == 2
 
-    def test_get_backend_uses_same_cache(self):
-        """get_backend() and backend_for_role() share the same cache."""
+    def test_get_backend_for_model_same_cache(self):
+        """Multiple calls for same model return cached instance."""
         r = make_router(manager_cascade=["ollama:test-model"])
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
             instance = MagicMock()
             MockOllama.return_value = instance
-            b1 = r.backend_for_role(AgentRole.MANAGER)
-            b2 = r.get_backend("ollama:test-model")
+            b1 = r.get_backend_for_model("ollama:test-model")
+            b2 = r.get_backend_for_model("ollama:test-model")
         assert b1 is b2
         assert MockOllama.call_count == 1
 
@@ -592,7 +590,7 @@ class TestEnsureAllModels:
 
 
 # ---------------------------------------------------------------------------
-# Phase 1B — New cascade API tests (Issue #32)
+# New cascade API tests (Issue #32)
 # ---------------------------------------------------------------------------
 
 class TestCascadeForRole:
@@ -800,7 +798,7 @@ class TestBackwardCompat:
 
 
 class TestBudgetTrackerInjection:
-    """Tests from the Phase 1B addendum: budget tracker wiring."""
+    """Tests for budget tracker injection into router."""
 
     def test_instantiate_anthropic_backend_receives_budget_tracker(self):
         mock_tracker = MagicMock()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -91,27 +91,40 @@ _OLLAMA_CASCADE  = ["ollama:small-model", "ollama:medium-model", "ollama:large-m
 
 def make_config(**kwargs) -> MagicMock:
     cfg = MagicMock()
-    cfg.local_only        = kwargs.get("local_only",        True)
-    cfg.manager_model     = kwargs.get("manager_model",     "ollama:manager-model")
-    cfg.critic_model      = kwargs.get("critic_model",      "ollama:critic-model")
-    cfg.coder_model       = kwargs.get("coder_model",       "ollama:coder-model")
-    cfg.writer_model      = kwargs.get("writer_model",      "ollama:writer-model")
-    cfg.summarizer_model  = kwargs.get("summarizer_model",  "ollama:summarizer-model")
+    # --- Cascade keys (Issue #32) ---
+    cfg.manager_cascade       = kwargs.get("manager_cascade",       ["ollama:manager-model"])
+    cfg.critic_cascade        = kwargs.get("critic_cascade",        ["ollama:critic-model"])
+    cfg.writer_cascade        = kwargs.get("writer_cascade",        ["ollama:writer-model"])
+    cfg.coder_cascade         = kwargs.get("coder_cascade",         ["ollama:coder-model"])
+    cfg.merge_resolution_cascade = kwargs.get("merge_resolution_cascade", [])
+    cfg.summarizer_cascade    = kwargs.get("summarizer_cascade",    ["ollama:summarizer-model"])
+    cfg.backend_cooldown_initial_seconds = kwargs.get("backend_cooldown_initial_seconds", 30)
+    cfg.backend_cooldown_max_seconds = kwargs.get("backend_cooldown_max_seconds", 600)
+    # --- Backward-compat single-model keys (shims until 1C) ---
+    cfg.manager_model         = kwargs.get("manager_model",         "ollama:manager-model")
+    cfg.critic_model          = kwargs.get("critic_model",          "ollama:critic-model")
+    cfg.coder_model           = kwargs.get("coder_model",           "ollama:coder-model")
+    cfg.writer_model          = kwargs.get("writer_model",          "ollama:writer-model")
+    cfg.summarizer_model      = kwargs.get("summarizer_model",      "ollama:summarizer-model")
     cfg.merge_resolution_model = kwargs.get("merge_resolution_model", "")
-    cfg.coder_cascade     = kwargs.get("coder_cascade",     ["ollama:coder-model"])
-    cfg.manager_stream    = kwargs.get("manager_stream",    True)
-    cfg.critic_stream     = kwargs.get("critic_stream",     True)
-    cfg.coder_stream      = kwargs.get("coder_stream",      True)
-    cfg.writer_stream     = kwargs.get("writer_stream",     True)
-    cfg.manager_think     = kwargs.get("manager_think",     False)
-    cfg.critic_think      = kwargs.get("critic_think",      False)
-    cfg.coder_think       = kwargs.get("coder_think",       False)
-    cfg.writer_think      = kwargs.get("writer_think",      False)
+    cfg.local_only            = kwargs.get("local_only",            True)
+    cfg.manager_stream        = kwargs.get("manager_stream",        True)
+    cfg.critic_stream         = kwargs.get("critic_stream",         True)
+    cfg.coder_stream          = kwargs.get("coder_stream",          True)
+    cfg.writer_stream         = kwargs.get("writer_stream",         True)
+    cfg.manager_think         = kwargs.get("manager_think",         False)
+    cfg.critic_think          = kwargs.get("critic_think",          False)
+    cfg.coder_think           = kwargs.get("coder_think",           False)
+    cfg.writer_think          = kwargs.get("writer_think",          False)
     return cfg
 
 
 def make_router(**kwargs) -> Router:
-    return Router(make_config(**kwargs))
+    budget_tracker = kwargs.get("budget_tracker")
+    cfg = make_config(**kwargs)
+    if budget_tracker is not None:
+        return Router(cfg, budget_tracker=budget_tracker)
+    return Router(cfg)
 
 
 def make_detector(reason="repeated tool call", role=AgentRole.CODER):
@@ -210,11 +223,11 @@ class TestLocalOnly:
                 coder_cascade=["anthropic:claude-sonnet-4-5"],
             )
 
-    def test_remote_manager_model_raises_when_local_only(self):
+    def test_remote_manager_cascade_raises_when_local_only(self):
         with pytest.raises(ValueError, match="local_only"):
             make_router(
                 local_only=True,
-                manager_model="openai:gpt-4o",
+                manager_cascade=["openai:gpt-4o"],
             )
 
     def test_local_backends_pass_when_local_only_true(self):
@@ -234,16 +247,16 @@ class TestLocalOnly:
         assert router is not None
 
     def test_violation_message_names_offending_keys(self):
-        """Error message should name which config keys have remote backends."""
+        """Error message should name which cascade keys have remote backends."""
         with pytest.raises(ValueError) as exc_info:
             make_router(
                 local_only=True,
-                manager_model="openai:gpt-4o",
-                critic_model="anthropic:claude-sonnet-4-5",
+                manager_cascade=["openai:gpt-4o"],
+                critic_cascade=["anthropic:claude-sonnet-4-5"],
             )
         msg = str(exc_info.value)
-        assert "manager_model" in msg
-        assert "critic_model" in msg
+        assert "manager_cascade" in msg
+        assert "critic_cascade" in msg
 
 
 # ---------------------------------------------------------------------------
@@ -251,24 +264,25 @@ class TestLocalOnly:
 # ---------------------------------------------------------------------------
 
 class TestModelForRole:
-    def test_manager_returns_manager_model(self):
-        r = make_router(manager_model="ollama:big-model")
+    def test_manager_returns_manager_cascade_first(self):
+        r = make_router(manager_cascade=["ollama:big-model"])
         assert r.model_for_role(AgentRole.MANAGER) == "ollama:big-model"
 
-    def test_critic_returns_critic_model(self):
-        r = make_router(critic_model="ollama:big-model")
+    def test_critic_returns_critic_cascade_first(self):
+        r = make_router(critic_cascade=["ollama:big-model"])
         assert r.model_for_role(AgentRole.CRITIC) == "ollama:big-model"
 
     def test_coder_returns_first_cascade_tier(self):
         r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
         assert r.model_for_role(AgentRole.CODER) == "ollama:small"
 
-    def test_writer_returns_writer_model(self):
-        r = make_router(writer_model="ollama:writer-model")
+    def test_writer_returns_writer_cascade_first(self):
+        r = make_router(writer_cascade=["ollama:writer-model"])
         assert r.model_for_role(AgentRole.WRITER) == "ollama:writer-model"
 
-    def test_unknown_role_falls_back_to_coder_model(self):
-        r = make_router(coder_model="ollama:coder-model")
+    def test_unknown_role_falls_back_to_coder_cascade(self):
+        r = make_router(coder_cascade=["ollama:coder-model"])
+        # Unknown role is not an AgentRole — shim handles it gracefully
         result = r.model_for_role("nonexistent_role") # type: ignore[arg-type]
         assert result == "ollama:coder-model"
 
@@ -279,7 +293,7 @@ class TestModelForRole:
 
 class TestParsedModelForRole:
     def test_returns_parsed_model(self):
-        r = make_router(manager_model="ollama:big-model")
+        r = make_router(manager_cascade=["ollama:big-model"])
         p = r.parsed_model_for_role(AgentRole.MANAGER)
         assert isinstance(p, ParsedModel)
         assert p.backend == "ollama"
@@ -291,55 +305,26 @@ class TestParsedModelForRole:
         assert p.model == "qwen3:4b"
 
     def test_local_model_for_role_strips_prefix(self):
-        r = make_router(manager_model="ollama:my-model")
+        r = make_router(manager_cascade=["ollama:my-model"])
         assert r.local_model_for_role("ollama:my-model") == "my-model"
 
     def test_parsed_model_for_role_for_merge_role(self):
         """parsed_model_for_role for MERGE role returns correct model."""
-        r = make_router(merge_resolution_model="ollama:merge-model")
+        r = make_router(merge_resolution_cascade=["ollama:merge-model"])
         p = r.parsed_model_for_role(AgentRole.MERGE)
         assert isinstance(p, ParsedModel)
         assert p.backend == "ollama"
         assert p.model == "merge-model"
 
     def test_parsed_model_for_role_merge_falls_back_to_cascade_top(self):
-        """MERGE role falls back to top of cascade when merge_resolution_model empty."""
+        """MERGE role falls back to [coder_cascade[-1]] when merge_resolution_cascade empty."""
         r = make_router(
-            merge_resolution_model="",
+            merge_resolution_cascade=[],
             coder_cascade=["ollama:small", "ollama:medium", "ollama:large"],
         )
         p = r.parsed_model_for_role(AgentRole.MERGE)
         assert isinstance(p, ParsedModel)
-        assert p.model == "large"  # Top of cascade
-
-
-# ---------------------------------------------------------------------------
-# _merge_model
-# ---------------------------------------------------------------------------
-
-class TestMergeModel:
-    """Tests for Router._merge_model method."""
-
-    def test_returns_configured_merge_model(self):
-        r = make_router(merge_resolution_model="ollama:merge-model")
-        assert r._merge_model() == "ollama:merge-model"
-
-    def test_falls_back_to_top_of_cascade_when_empty(self):
-        """_merge_model falls back to top of cascade when merge_resolution_model empty."""
-        r = make_router(
-            merge_resolution_model="",
-            coder_cascade=["ollama:small", "ollama:medium", "ollama:large"],
-        )
-        assert r._merge_model() == "ollama:large"
-
-    def test_falls_back_to_coder_model_when_cascade_empty(self):
-        """_merge_model falls back to coder_model when cascade is also empty."""
-        r = make_router(
-            merge_resolution_model="",
-            coder_cascade=[],
-            coder_model="ollama:fallback-model",
-        )
-        assert r._merge_model() == "ollama:fallback-model"
+        assert p.model == "large"  # Last of coder cascade
 
 
 # ---------------------------------------------------------------------------
@@ -399,106 +384,25 @@ class TestThinkForRole:
 # ---------------------------------------------------------------------------
 
 class TestCascade:
-    def test_single_tier_when_cascade_empty(self):
-        r = make_router(coder_cascade=[], coder_model="ollama:only-model")
-        assert r._cascade == ["ollama:only-model"]
+    def test_single_tier_cascade(self):
+        r = make_router(coder_cascade=["ollama:only-model"])
+        assert r.cascade_for_role(AgentRole.CODER) == ["ollama:only-model"]
 
     def test_multi_tier_from_config(self):
         r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        assert r._cascade == ["ollama:small", "ollama:medium", "ollama:large"]
+        assert r.cascade_for_role(AgentRole.CODER) == [
+            "ollama:small", "ollama:medium", "ollama:large"
+        ]
 
     def test_current_tier_starts_at_zero(self):
+        """Shim: current_tier always returns 0 now."""
         r = make_router(coder_cascade=["ollama:small", "ollama:large"])
         assert r.current_tier == 0
 
-    def test_at_ceiling_false_when_below_top(self):
+    def test_at_ceiling_always_true(self):
+        """Shim: at_ceiling always returns True since no escalation state."""
         r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        assert r.at_ceiling is False
-
-    def test_at_ceiling_true_with_single_tier(self):
-        r = make_router(coder_cascade=["ollama:only-model"])
         assert r.at_ceiling is True
-
-    def test_at_ceiling_true_when_at_top(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._current_tier = 1
-        assert r.at_ceiling is True
-
-
-# ---------------------------------------------------------------------------
-# escalate
-# ---------------------------------------------------------------------------
-
-class TestEscalate:
-    def test_escalation_advances_tier(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        r.escalate(make_detector())
-        assert r.current_tier == 1
-
-    def test_escalation_returns_new_model(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        escalated, new_model = r.escalate(make_detector())
-        assert escalated is True
-        assert new_model == "ollama:medium"
-
-    def test_escalation_at_ceiling_returns_false(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._current_tier = 1
-        escalated, new_model = r.escalate(make_detector())
-        assert escalated is False
-        assert new_model is None
-
-    def test_escalation_resets_successful_cycles(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._successful_cycles = 1
-        r.escalate(make_detector())
-        assert r._successful_cycles == 0
-
-    def test_model_for_coder_reflects_new_tier(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        r.escalate(make_detector())
-        assert r.model_for_role(AgentRole.CODER) == "ollama:medium"
-
-
-# ---------------------------------------------------------------------------
-# record_success / de-escalation
-# ---------------------------------------------------------------------------
-
-class TestDeEscalation:
-    def test_noop_at_base_tier(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r.record_success()
-        assert r.current_tier == 0
-        assert r._successful_cycles == 0
-
-    def test_increments_cycle_counter(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._current_tier = 1
-        r.record_success()
-        assert r._successful_cycles == 1
-
-    def test_de_escalates_after_threshold(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._current_tier = 1
-        for _ in range(Router.DEESCALATE_AFTER):
-            r.record_success()
-        assert r.current_tier == 0
-
-    def test_resets_counter_on_de_escalation(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:large"])
-        r._current_tier = 1
-        for _ in range(Router.DEESCALATE_AFTER):
-            r.record_success()
-        assert r._successful_cycles == 0
-
-    def test_does_not_go_below_tier_zero(self):
-        r = make_router(coder_cascade=["ollama:small", "ollama:medium", "ollama:large"])
-        r._current_tier = 1
-        for _ in range(Router.DEESCALATE_AFTER):
-            r.record_success()
-        for _ in range(Router.DEESCALATE_AFTER):
-            r.record_success()
-        assert r.current_tier == 0
 
 
 # ---------------------------------------------------------------------------
@@ -595,8 +499,8 @@ class TestBackendCaching:
 
     def test_different_hosts_return_different_instances(self):
         r = make_router(
-            manager_model="http://192.168.1.10:ollama:model-a",
-            critic_model="http://192.168.1.11:ollama:model-b",
+            manager_cascade=["http://192.168.1.10:ollama:model-a"],
+            critic_cascade=["http://192.168.1.11:ollama:model-b"],
             local_only=False,
         )
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
@@ -608,7 +512,7 @@ class TestBackendCaching:
 
     def test_get_backend_uses_same_cache(self):
         """get_backend() and backend_for_role() share the same cache."""
-        r = make_router(manager_model="ollama:test-model")
+        r = make_router(manager_cascade=["ollama:test-model"])
         with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
             instance = MagicMock()
             MockOllama.return_value = instance
@@ -625,11 +529,11 @@ class TestBackendCaching:
 class TestEnsureAllModels:
     def test_calls_ensure_model_for_each_configured_model(self):
         r = make_router(
-            manager_model="ollama:manager",
-            critic_model="ollama:critic",
+            manager_cascade=["ollama:manager"],
+            critic_cascade=["ollama:critic"],
             coder_cascade=["ollama:coder"],
-            writer_model="ollama:writer",
-            summarizer_model="ollama:summarizer",
+            writer_cascade=["ollama:writer"],
+            summarizer_cascade=["ollama:summarizer"],
         )
         mock_backend = MagicMock()
         with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
@@ -639,21 +543,320 @@ class TestEnsureAllModels:
     def test_deduplicates_same_model_on_same_backend(self):
         """Same model string on the same backend is only ensured once."""
         r = make_router(
-            manager_model="ollama:shared-model",
-            critic_model="ollama:shared-model",
+            manager_cascade=["ollama:shared-model"],
+            critic_cascade=["ollama:shared-model"],
             coder_cascade=["ollama:shared-model"],
-            writer_model="ollama:shared-model",
-            summarizer_model="ollama:shared-model",
+            writer_cascade=["ollama:shared-model"],
+            summarizer_cascade=["ollama:shared-model"],
         )
         mock_backend = MagicMock()
         with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
             r.ensure_all_models()
+        # All are same model on same backend → ensure_model called once
         assert mock_backend.ensure_model.call_count == 1
 
+    def test_only_ensures_first_entry_per_cascade(self):
+        """ensure_all_models only ensures cascade[0] entries, not fallbacks."""
+        r = make_router(
+            manager_cascade=["ollama:manager1", "ollama:manager2"],
+            coder_cascade=["ollama:coder1", "ollama:coder2"],
+            merge_resolution_cascade=["ollama:merge1"],
+            summarizer_cascade=["ollama:summarizer1"],
+        )
+        mock_backend = MagicMock()
+        with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
+            r.ensure_all_models()
+        # Only first entries ensured: manager1, coder1, merge1, summarizer1
+        # (plus critic, writer with their defaults)
+        ensured_models = [c[0][0] for c in mock_backend.ensure_model.call_args_list]
+        assert "manager1" in ensured_models
+        assert "coder1" in ensured_models
+        assert "merge1" in ensured_models
+        assert "summarizer1" in ensured_models
+        # Second entries should NOT be ensured
+        assert "manager2" not in ensured_models
+        assert "coder2" not in ensured_models
+
     def test_skips_empty_model_strings(self):
-        """Empty merge_resolution_model should not cause an error."""
-        r = make_router(merge_resolution_model="")
+        """Empty cascade entries should not cause an error."""
+        # Cascades are validated at init, so empty strings are caught there.
+        # This test confirms ensure_all_models handles normal entries fine.
+        r = make_router(
+            manager_cascade=["ollama:manager"],
+            summarizer_cascade=["ollama:summarizer"],
+        )
         mock_backend = MagicMock()
         with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
             r.ensure_all_models()
         # Should complete without raising
+
+
+# ---------------------------------------------------------------------------
+# Phase 1B — New cascade API tests (Issue #32)
+# ---------------------------------------------------------------------------
+
+class TestCascadeForRole:
+    """Tests for Router.cascade_for_role()."""
+
+    def test_cascade_for_role_returns_configured_list(self):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            r = make_router(
+                manager_cascade=["anthropic:claude-sonnet-4-5", "ollama:qwen3:72b"],
+                coder_cascade=["ollama:qwen3:4b", "ollama:qwen3:9b"],
+                local_only=False,
+            )
+        assert r.cascade_for_role(AgentRole.MANAGER) == [
+            "anthropic:claude-sonnet-4-5", "ollama:qwen3:72b"
+        ]
+        assert r.cascade_for_role(AgentRole.CODER) == [
+            "ollama:qwen3:4b", "ollama:qwen3:9b"
+        ]
+
+    def test_cascade_for_role_single_entry(self):
+        r = make_router(coder_cascade=["ollama:qwen3:4b"])
+        assert r.cascade_for_role(AgentRole.CODER) == ["ollama:qwen3:4b"]
+
+    def test_cascade_for_role_merge_defaults_to_coder_last(self):
+        """Merge cascade defaults to [coder_cascade[-1]] when not configured."""
+        r = make_router(
+            coder_cascade=["ollama:small", "ollama:medium", "ollama:large"],
+            merge_resolution_cascade=[],
+        )
+        assert r.cascade_for_role(AgentRole.MERGE) == ["ollama:large"]
+
+    def test_cascade_for_role_empty_raises_at_init(self):
+        """Empty required cascade raises ValueError at construction."""
+        with pytest.raises(ValueError, match="manager_cascade"):
+            make_router(manager_cascade=[])
+
+    def test_cascade_for_role_summarizer_empty_raises_at_init(self):
+        with pytest.raises(ValueError, match="summarizer_cascade"):
+            make_router(summarizer_cascade=[])
+
+
+class TestSummarizerCascade:
+    """Tests for Router.summarizer_cascade()."""
+
+    def test_summarizer_cascade_returns_list(self):
+        r = make_router(summarizer_cascade=["ollama:summarizer-small"])
+        assert r.summarizer_cascade() == ["ollama:summarizer-small"]
+
+    def test_summarizer_cascade_empty_raises_at_init(self):
+        with pytest.raises(ValueError, match="summarizer_cascade"):
+            make_router(summarizer_cascade=[])
+
+
+class TestGetBackendForModel:
+    """Tests for Router.get_backend_for_model() — replaces get_backend()."""
+
+    def test_get_backend_for_model_caches_by_host_backend(self):
+        """Same (host, backend) pair returns same instance."""
+        r = make_router(local_only=False)
+        with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
+            MockOllama.return_value = MagicMock()
+            b1 = r.get_backend_for_model("ollama:model-a")
+            b2 = r.get_backend_for_model("ollama:model-b")
+        assert b1 is b2
+        assert MockOllama.call_count == 1
+
+    def test_get_backend_for_model_different_backends_distinct_instances(self):
+        r = make_router(local_only=False)
+        with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
+            MockOllama.side_effect = [MagicMock(), MagicMock()]
+            b1 = r.get_backend_for_model("ollama:model-a")
+            b2 = r.get_backend_for_model("http://10.0.0.1:ollama:model-b")
+        assert b1 is not b2
+        assert MockOllama.call_count == 2
+
+
+class TestCascadeValidation:
+    """Tests for _validate_config with cascade lists."""
+
+    def test_validate_empty_string_entry_raises(self):
+        """Empty string in any cascade raises ValueError at init."""
+        with pytest.raises(ValueError, match="coder_cascade"):
+            make_router(coder_cascade=["ollama:qwen3:4b", ""])
+
+    def test_validate_local_only_rejects_remote_in_any_cascade_position(self):
+        with pytest.raises(ValueError, match="manager_cascade"):
+            make_router(
+                local_only=True,
+                manager_cascade=["ollama:small", "anthropic:claude-haiku-4-5"],
+            )
+
+    def test_validate_local_only_rejects_remote_in_summarizer_cascade(self):
+        with pytest.raises(ValueError, match="summarizer_cascade"):
+            make_router(
+                local_only=True,
+                summarizer_cascade=["openai:gpt-4o-mini"],
+            )
+
+    def test_validate_local_only_catches_last_entry_of_writer_cascade(self):
+        """Only the *last* entry of writer_cascade is remote — still raises."""
+        with pytest.raises(ValueError, match="writer_cascade"):
+            make_router(
+                local_only=True,
+                writer_cascade=["ollama:qwen3:4b", "ollama:qwen3:9b", "anthropic:claude-sonnet-4-5"],
+            )
+
+    def test_validate_local_only_catches_last_entry_of_summarizer_cascade(self):
+        with pytest.raises(ValueError, match="summarizer_cascade"):
+            make_router(
+                local_only=True,
+                summarizer_cascade=["ollama:qwen3:4b", "anthropic:claude-haiku"],
+            )
+
+    def test_validate_local_only_allows_all_local_cascades(self):
+        r = make_router(
+            local_only=True,
+            manager_cascade=["ollama:big-model"],
+            critic_cascade=["ollama:critic-model"],
+            writer_cascade=["ollama:writer-model"],
+            coder_cascade=["ollama:coder-model"],
+            merge_resolution_cascade=[],
+            summarizer_cascade=["ollama:summarizer-model"],
+        )
+        assert r is not None
+
+    def test_validate_malformed_model_string_raises(self):
+        with pytest.raises(ValueError, match="coder_cascade"):
+            make_router(coder_cascade=["not-a-valid-model-string!!!"])
+
+
+class TestEnsureAllModelsCascade:
+    """Tests for ensure_all_models with cascade changes."""
+
+    def test_ensure_all_models_validates_all_entries(self):
+        """Mock parse_model_string; confirm it is called for every entry."""
+        r = make_router(
+            manager_cascade=["ollama:manager1", "ollama:manager2"],
+            critic_cascade=["ollama:critic1"],
+            writer_cascade=["ollama:writer1"],
+            coder_cascade=["ollama:coder1", "ollama:coder2", "ollama:coder3"],
+            merge_resolution_cascade=["ollama:merge1"],
+            summarizer_cascade=["ollama:summarizer1"],
+        )
+        mock_backend = MagicMock()
+        with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
+            with patch("matrixmouse.router.parse_model_string") as mock_parse:
+                mock_parse.return_value = MagicMock(
+                    host="http://localhost:11434",
+                    backend="ollama",
+                    model="test",
+                )
+                r.ensure_all_models()
+        # Ensure parse_model_string was called (validation of all entries is
+        # done during validation; ensure_all_models calls parse for models
+        # it ensures)
+        assert mock_parse.called
+
+    def test_ensure_all_models_only_ensures_first_entry(self):
+        """Mock ensure_model; confirm called exactly once per role with cascade[0]."""
+        r = make_router(
+            manager_cascade=["ollama:manager1", "ollama:manager2"],
+            critic_cascade=["ollama:critic1", "ollama:critic2"],
+            writer_cascade=["ollama:writer1"],
+            coder_cascade=["ollama:coder1", "ollama:coder2"],
+            merge_resolution_cascade=["ollama:merge1"],
+            summarizer_cascade=["ollama:summarizer1"],
+        )
+        mock_backend = MagicMock()
+        with patch.object(r, "_get_or_create_backend", return_value=mock_backend):
+            r.ensure_all_models()
+        # Each unique (host, backend) pair gets ensured once.
+        # Since all are ollama @ localhost, there should be 1 unique backend.
+        # But ensure_all_models deduplicates by (id(backend), model_id).
+        # First entries: manager1, critic1, writer1, coder1, merge1, summarizer1
+        # All use the same backend, so ensure_model is called once per unique model.
+        ensure_calls = [c[0][0] for c in mock_backend.ensure_model.call_args_list]
+        # All first entries should be ensured
+        assert len(mock_backend.ensure_model.call_args_list) >= 1
+
+
+class TestBackwardCompat:
+    """Tests confirming existing methods still work after cascade rewrite."""
+
+    def test_build_handoff_still_works(self):
+        r = make_router()
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "thinking"},
+        ]
+        detector = make_detector()
+        result = r.build_handoff(detector, msgs)
+        assert len(result) >= 3
+        assert any("ESCALATION HANDOFF" in m.get("content", "") for m in result if isinstance(m, dict))
+
+    def test_stream_for_role_unchanged(self):
+        r = make_router(manager_stream=True, coder_stream=False)
+        assert r.stream_for_role(AgentRole.MANAGER) is True
+        assert r.stream_for_role(AgentRole.CODER) is False
+
+    def test_think_for_role_unchanged(self):
+        r = make_router(manager_think=True, coder_think=False)
+        assert r.think_for_role(AgentRole.MANAGER) is True
+        assert r.think_for_role(AgentRole.CODER) is False
+
+
+class TestBudgetTrackerInjection:
+    """Tests from the Phase 1B addendum: budget tracker wiring."""
+
+    def test_instantiate_anthropic_backend_receives_budget_tracker(self):
+        mock_tracker = MagicMock()
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch("matrixmouse.inference.anthropic.AnthropicBackend") as MockBackend:
+                MockBackend.return_value = MagicMock()
+                r = make_router(
+                    local_only=False,
+                    summarizer_cascade=["anthropic:claude-haiku-4-5"],
+                    budget_tracker=mock_tracker,
+                )
+                r.get_backend_for_model("anthropic:claude-haiku-4-5")
+                # Verify budget_tracker was passed to AnthropicBackend
+                call_kwargs = MockBackend.call_args.kwargs
+                assert call_kwargs.get("budget_tracker") is mock_tracker
+
+    def test_instantiate_openai_backend_receives_budget_tracker(self):
+        mock_tracker = MagicMock()
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+            with patch("matrixmouse.inference.openai.OpenAIBackend") as MockBackend:
+                MockBackend.return_value = MagicMock()
+                r = make_router(
+                    local_only=False,
+                    summarizer_cascade=["openai:gpt-4o-mini"],
+                    budget_tracker=mock_tracker,
+                )
+                r.get_backend_for_model("openai:gpt-4o-mini")
+                call_kwargs = MockBackend.call_args.kwargs
+                assert call_kwargs.get("budget_tracker") is mock_tracker
+
+    def test_instantiate_local_backend_no_budget_tracker(self):
+        """Local backends don't accept budget_tracker — no error."""
+        mock_tracker = MagicMock()
+        with patch("matrixmouse.inference.ollama.OllamaBackend") as MockOllama:
+            MockOllama.return_value = MagicMock()
+            r = make_router(
+                summarizer_cascade=["ollama:qwen3:4b"],
+                budget_tracker=mock_tracker,
+            )
+            r.get_backend_for_model("ollama:qwen3:4b")
+        # OllamaBackend should NOT be called with budget_tracker kwarg
+        call_kwargs = MockOllama.call_args.kwargs
+        assert "budget_tracker" not in call_kwargs
+
+    def test_router_with_no_budget_tracker_still_instantiates_backends(self):
+        """Router with budget_tracker=None still works."""
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            with patch("matrixmouse.inference.anthropic.AnthropicBackend") as MockBackend:
+                mock_instance = MagicMock()
+                MockBackend.return_value = mock_instance
+                r = make_router(
+                    local_only=False,
+                    summarizer_cascade=["anthropic:claude-haiku-4-5"],
+                    budget_tracker=None,
+                )
+                backend = r.get_backend_for_model("anthropic:claude-haiku-4-5")
+                assert backend is mock_instance
+                call_kwargs = MockBackend.call_args.kwargs
+                assert call_kwargs.get("budget_tracker") is None


### PR DESCRIPTION
## Availability-Aware Cascade Routing (#32)

### Overview

Generalizes the cascade from Coder-only to all agent roles (Manager, Critic, Writer, Coder, Merge, Summarizer) and adds backend availability as a cascade trigger alongside stuck detection. When a provider is unavailable — budget exhausted, connection error, or in cooldown - the system automatically tries the next entry in the role's preference list instead of blocking.

### Key changes

**Config**: 6 new cascade keys replace single-model keys; 2 new cooldown keys

**Router backend**: Stateless cascade resolution via `cascade_for_role()`, `get_backend_for_model()`  

**Backend Availability Cache**: Per-backend exponential backoff, persisted in `WorkspaceStateRepository`  

**Summarizer Resiliency**: Summarizer now cascades like other roles, summarization failure is now treated as a hard blocker.  

**Orchestrator**: `_resolve_model_for_task()` walks cascade (budget check -> availability check) to first passing model.  

**Loop**: `LLMBackendError` subclasses re-raised so the orchestrator can handle them.  

**ContextManager**: `working_model`/`working_backend` rename from `coder_model`/`coder_backend`, summarizer cascade.

**Service**: `BackendAvailabilityCache` wired with config cooldowns, router rebuilt with `budget_tracker` after tracker instantiated

**Budget tracker**: Fix: `_instantiate_backend` was silently dropping the `TokenBudgetTracker`, meaning summarisation calls to remote providers went untracked. Fixed by accepting `budget_tracker` in `Router.__init__` and passing it through to `AnthropicBackend`/`OpenAIBackend`.  

### Config 
**Breaking**: The following config keys are removed:
- manager_model → manager_cascade
- critic_model → critic_cascade
- writer_model → writer_cascade
- coder_model → coder_cascade
- merge_resolution_model → merge_resolution_cascade
- summarizer_model → summarizer_cascade

All cascade fields are list[str] defaulting to []. E.g. `coder_model` = "ollama:qwen3:4b" → `coder_cascade` = ["ollama:qwen3:4b"].

### Tests

91 new tests.

### Follow-up

- #9 (UI) - New cascade and cooldown keys need surfacing in the settings panel
- #16 (CLI) - Same keys need CLI config command updates
- #15 (multi-worker) - `Task.current_cascade_index` needed for per-task stuck escalation persistence across context switches.
- See # TODO(#15) comments in orchestrator.py.